### PR TITLE
Add device authentication with API tokens

### DIFF
--- a/middleware/deviceAuth.js
+++ b/middleware/deviceAuth.js
@@ -1,0 +1,114 @@
+const { getFirestore } = require('../config/firebase');
+
+/**
+ * Device Authentication Middleware
+ * Validates device API tokens for ESP32 devices
+ */
+const authenticateDevice = async (req, res, next) => {
+  try {
+    // Get token from Authorization header
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        status: 'error',
+        message: 'Missing or invalid Authorization header. Expected: Bearer <token>'
+      });
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    if (!token) {
+      return res.status(401).json({
+        status: 'error',
+        message: 'No token provided'
+      });
+    }
+
+    // Get device_id from request body
+    const { device_id } = req.body;
+
+    if (!device_id) {
+      return res.status(400).json({
+        status: 'error',
+        message: 'device_id required in request body'
+      });
+    }
+
+    // Verify token matches device in Firestore
+    const db = getFirestore();
+    const deviceDoc = await db.collection('devices').doc(device_id).get();
+
+    if (!deviceDoc.exists) {
+      return res.status(404).json({
+        status: 'error',
+        message: 'Device not found. Register device first.'
+      });
+    }
+
+    const deviceData = deviceDoc.data();
+
+    // Check if token matches
+    if (deviceData.api_token !== token) {
+      console.warn(`[AUTH] Invalid token attempt for device: ${device_id}`);
+      return res.status(403).json({
+        status: 'error',
+        message: 'Invalid token for this device'
+      });
+    }
+
+    // Check if device is disabled
+    if (deviceData.disabled === true) {
+      return res.status(403).json({
+        status: 'error',
+        message: 'Device has been disabled'
+      });
+    }
+
+    // Token valid - attach device info to request
+    req.device = {
+      id: device_id,
+      type: deviceData.type,
+      name: deviceData.name
+    };
+
+    next();
+  } catch (error) {
+    console.error('[AUTH] Error:', error);
+    res.status(500).json({
+      status: 'error',
+      message: 'Authentication error'
+    });
+  }
+};
+
+/**
+ * Optional: Simpler API key authentication (less secure, easier)
+ * Use a single shared secret for all devices
+ */
+const authenticateSimpleApiKey = (req, res, next) => {
+  const apiKey = req.headers['x-api-key'];
+  const validApiKey = process.env.DEVICE_API_KEY;
+
+  if (!apiKey) {
+    return res.status(401).json({
+      status: 'error',
+      message: 'Missing X-API-Key header'
+    });
+  }
+
+  if (apiKey !== validApiKey) {
+    console.warn('[AUTH] Invalid API key attempt');
+    return res.status(403).json({
+      status: 'error',
+      message: 'Invalid API key'
+    });
+  }
+
+  next();
+};
+
+module.exports = {
+  authenticateDevice,
+  authenticateSimpleApiKey
+};

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -4,18 +4,25 @@ const {
   handleHeartbeat,
   getDeviceStatus,
   handleSensorData,
-  getDeviceHistory
+  getDeviceHistory,
+  registerDevice
 } = require('../controllers/devices');
+const { authenticateDevice } = require('../middleware/deviceAuth');
+
+// @route   POST /api/v1/devices/register
+// @desc    Register a new device (admin only - call manually or via secure endpoint)
+// @access  Public (TODO: Add admin auth)
+router.post('/register', registerDevice);
 
 // @route   POST /api/v1/devices/heartbeat
 // @desc    Receive device heartbeat (always responds, throttles Firebase writes)
-// @access  Public (add auth later)
-router.post('/heartbeat', handleHeartbeat);
+// @access  Private (requires device token)
+router.post('/heartbeat', authenticateDevice, handleHeartbeat);
 
 // @route   POST /api/v1/devices/sensor
 // @desc    Receive sensor data (throttled writes)
-// @access  Public
-router.post('/sensor', handleSensorData);
+// @access  Private (requires device token)
+router.post('/sensor', authenticateDevice, handleSensorData);
 
 // @route   GET /api/v1/devices/:device_id/status
 // @desc    Get current device status


### PR DESCRIPTION
- Create deviceAuth middleware for token validation
- Add device registration endpoint
- Generate secure random tokens (64 hex chars)
- Protect heartbeat and sensor endpoints with authentication
- Each device gets unique token stored in Firestore
- Support for disabling compromised devices

Security features:
- Bearer token authentication
- Device-specific tokens (not shared secret)
- Token validation against Firestore
- Can revoke individual device access