### PR TITLE
Add device authentication with API tokens to ESP32

### DIFF
--- a/include/heartbeat.h
+++ b/include/heartbeat.h
@@ -7,9 +7,10 @@
 extern const char* BACKEND_SERVER_URL;
 extern const char* DEVICE_ID;
 extern const char* DEVICE_TYPE;
+extern const char* DEVICE_API_TOKEN;
 
 // Initialize heartbeat module
-void initHeartbeat(const char* serverUrl, const char* deviceId, const char* deviceType);
+void initHeartbeat(const char* serverUrl, const char* deviceId, const char* deviceType, const char* apiToken);
 
 // Send heartbeat to backend server
 void sendHeartbeat();

--- a/src/heartbeat.cpp
+++ b/src/heartbeat.cpp
@@ -7,6 +7,7 @@
 const char* BACKEND_SERVER_URL = "";
 const char* DEVICE_ID = "";
 const char* DEVICE_TYPE = "";
+const char* DEVICE_API_TOKEN = "";
 
 // Status tracking
 static bool lastHeartbeatSuccess = false;
@@ -15,14 +16,16 @@ static unsigned long lastHeartbeatTime = 0;
 // ============================================================================
 // Initialize heartbeat module with server config
 // ============================================================================
-void initHeartbeat(const char* serverUrl, const char* deviceId, const char* deviceType) {
+void initHeartbeat(const char* serverUrl, const char* deviceId, const char* deviceType, const char* apiToken) {
   BACKEND_SERVER_URL = serverUrl;
   DEVICE_ID = deviceId;
   DEVICE_TYPE = deviceType;
+  DEVICE_API_TOKEN = apiToken;
 
   Serial.println("[Heartbeat] Initialized");
   Serial.printf("  Server: %s\n", serverUrl);
   Serial.printf("  Device: %s (%s)\n", deviceId, deviceType);
+  Serial.printf("  Token: %s\n", apiToken && strlen(apiToken) > 0 ? "***configured***" : "NOT SET");
 }
 
 // ============================================================================
@@ -41,6 +44,13 @@ void sendHeartbeat() {
 
   http.begin(url);
   http.addHeader("Content-Type", "application/json");
+
+  // Add Authorization header with Bearer token
+  if (DEVICE_API_TOKEN && strlen(DEVICE_API_TOKEN) > 0) {
+    String authHeader = String("Bearer ") + DEVICE_API_TOKEN;
+    http.addHeader("Authorization", authHeader.c_str());
+  }
+
   http.setTimeout(5000); // 5 second timeout
 
   // Build JSON payload
@@ -104,6 +114,13 @@ void sendSensorData(float temperature, float humidity, int motion) {
 
   http.begin(url);
   http.addHeader("Content-Type", "application/json");
+
+  // Add Authorization header with Bearer token
+  if (DEVICE_API_TOKEN && strlen(DEVICE_API_TOKEN) > 0) {
+    String authHeader = String("Bearer ") + DEVICE_API_TOKEN;
+    http.addHeader("Authorization", authHeader.c_str());
+  }
+
   http.setTimeout(5000);
 
   // Build JSON payload

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,8 +256,13 @@ void setup()
   fetchWeatherTask();
 
   // Initialize heartbeat module
-  // TODO: Update server URL to your deployed backend
-  initHeartbeat("http://your-server.fly.dev", "doorbell_001", "doorbell");
+  // TODO: Update these values after registering the device with the backend
+  initHeartbeat(
+    "https://embedded-smarthome.fly.dev",  // Your backend URL
+    "doorbell_001",                         // Device ID
+    "doorbell",                              // Device type
+    "YOUR_DEVICE_TOKEN_HERE"                // API token (get from /api/v1/devices/register)
+  );
   Serial.println("[MAIN] Heartbeat module initialized");
 
   // Configure TJpg_Decoder


### PR DESCRIPTION
- Update heartbeat module to send Bearer token in Authorization header
- Add api_token parameter to initHeartbeat()
- Configure for embedded-smarthome.fly.dev backend
- Update documentation with security setup instructions

Security features:
- Each device has unique 64-char hex token
- Token sent with every heartbeat/sensor request
- Backend validates token against Firestore
- Prevents unauthorized data injection and API spam

Setup:
1. Register device: POST /api/v1/devices/register
2. Save returned token
3. Configure in main.cpp initHeartbeat()
4. Flash ESP32