### PR TITLE
Refactor: Separate WiFi init from heartbeat module

### DIFF
--- a/include/hub_network.h
+++ b/include/hub_network.h
@@ -3,17 +3,6 @@
 
 #include <Arduino.h>
 
-// Configuration
-extern const char* WIFI_SSID;
-extern const char* WIFI_PASSWORD;
-extern const char* BACKEND_SERVER_URL;
-extern const char* HUB_DEVICE_ID;
-extern const char* HUB_DEVICE_TYPE;
-extern const char* HUB_API_TOKEN;
-
-// Doorbell device to monitor
-extern const char* DOORBELL_DEVICE_ID;
-
 // Device status structure
 struct DeviceStatus {
   bool online;
@@ -24,19 +13,16 @@ struct DeviceStatus {
   bool data_valid;
 };
 
-// Initialize network and heartbeat
-void initNetwork(const char* ssid, const char* password, const char* serverUrl,
-                 const char* deviceId, const char* deviceType, const char* apiToken,
-                 const char* doorbellId);
+// Initialize heartbeat module (WiFi must already be connected)
+void initHeartbeat(const char* serverUrl, const char* deviceId,
+                   const char* deviceType, const char* apiToken,
+                   const char* doorbellId);
 
 // Send hub's own heartbeat
 void sendHubHeartbeat();
 
 // Check if doorbell is online
 DeviceStatus checkDoorbellStatus();
-
-// Get WiFi status
-bool isWiFiConnected();
 
 // Get last heartbeat status
 bool getLastHeartbeatSuccess();

--- a/src/hub_network.cpp
+++ b/src/hub_network.cpp
@@ -4,56 +4,29 @@
 #include <ArduinoJson.h>
 
 // Configuration variables
-const char* WIFI_SSID = "";
-const char* WIFI_PASSWORD = "";
-const char* BACKEND_SERVER_URL = "";
-const char* HUB_DEVICE_ID = "";
-const char* HUB_DEVICE_TYPE = "";
-const char* HUB_API_TOKEN = "";
-const char* DOORBELL_DEVICE_ID = "";
+static const char* BACKEND_SERVER_URL = "";
+static const char* HUB_DEVICE_ID = "";
+static const char* HUB_DEVICE_TYPE = "";
+static const char* HUB_API_TOKEN = "";
+static const char* DOORBELL_DEVICE_ID = "";
 
 // Status tracking
 static bool lastHeartbeatSuccess = false;
 static unsigned long lastHeartbeatTime = 0;
 
 // ============================================================================
-// Initialize network and configure heartbeat
+// Initialize heartbeat module (WiFi must already be connected)
 // ============================================================================
-void initNetwork(const char* ssid, const char* password, const char* serverUrl,
-                 const char* deviceId, const char* deviceType, const char* apiToken,
-                 const char* doorbellId) {
-  WIFI_SSID = ssid;
-  WIFI_PASSWORD = password;
+void initHeartbeat(const char* serverUrl, const char* deviceId,
+                   const char* deviceType, const char* apiToken,
+                   const char* doorbellId) {
   BACKEND_SERVER_URL = serverUrl;
   HUB_DEVICE_ID = deviceId;
   HUB_DEVICE_TYPE = deviceType;
   HUB_API_TOKEN = apiToken;
   DOORBELL_DEVICE_ID = doorbellId;
 
-  // Connect to WiFi
-  Serial.println("\n[Network] Connecting to WiFi...");
-  Serial.printf("  SSID: %s\n", ssid);
-
-  WiFi.mode(WIFI_STA);
-  WiFi.setAutoReconnect(true);
-  WiFi.begin(ssid, password);
-
-  int timeout = 20; // 20 seconds
-  while (WiFi.status() != WL_CONNECTED && timeout > 0) {
-    delay(500);
-    Serial.print(".");
-    timeout--;
-  }
-
-  if (WiFi.status() == WL_CONNECTED) {
-    Serial.println("\n[Network] ✓ WiFi Connected!");
-    Serial.printf("  IP: %s\n", WiFi.localIP().toString().c_str());
-    Serial.printf("  RSSI: %d dBm\n", WiFi.RSSI());
-  } else {
-    Serial.println("\n[Network] ✗ WiFi Connection Failed!");
-  }
-
-  Serial.println("[Network] Heartbeat initialized");
+  Serial.println("[Heartbeat] Initialized");
   Serial.printf("  Server: %s\n", serverUrl);
   Serial.printf("  Hub ID: %s (%s)\n", deviceId, deviceType);
   Serial.printf("  Token: %s\n", apiToken && strlen(apiToken) > 0 ? "***configured***" : "NOT SET");
@@ -181,10 +154,6 @@ DeviceStatus checkDoorbellStatus() {
 // ============================================================================
 // Helper functions
 // ============================================================================
-bool isWiFiConnected() {
-  return WiFi.status() == WL_CONNECTED;
-}
-
 bool getLastHeartbeatSuccess() {
   return lastHeartbeatSuccess;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <Panel_RA8875_Fixed.h>
 #include "TaskScheduler.h"
 #include <Wire.h>
+#include <WiFi.h>
 #include <Touch.h>
 #include <CapSensor.h>
 #include "hub_network.h"
@@ -140,11 +141,31 @@ void setup(void)
       break;
   }
 
-  // Initialize network and heartbeat
-  // TODO: Update WiFi credentials and device tokens
-  initNetwork(
-    "YOUR_WIFI_SSID",                       // WiFi SSID
-    "YOUR_WIFI_PASSWORD",                   // WiFi password
+  // Initialize WiFi
+  // TODO: Update WiFi credentials
+  Serial.println("\n[WiFi] Connecting...");
+  WiFi.mode(WIFI_STA);
+  WiFi.setAutoReconnect(true);
+  WiFi.begin("YOUR_WIFI_SSID", "YOUR_WIFI_PASSWORD");
+
+  int timeout = 20;
+  while (WiFi.status() != WL_CONNECTED && timeout > 0) {
+    delay(500);
+    Serial.print(".");
+    timeout--;
+  }
+
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.println("\n[WiFi] ✓ Connected!");
+    Serial.printf("  IP: %s\n", WiFi.localIP().toString().c_str());
+    Serial.printf("  RSSI: %d dBm\n", WiFi.RSSI());
+  } else {
+    Serial.println("\n[WiFi] ✗ Connection Failed!");
+  }
+
+  // Initialize heartbeat module (WiFi must be connected first)
+  // TODO: Update device tokens
+  initHeartbeat(
     "http://embedded-smarthome.fly.dev",   // Backend URL
     "hub_001",                              // Hub device ID
     "hub",                                  // Device type
@@ -200,7 +221,7 @@ void DisplayUpdate()
   lcd.drawString("ESP32 Hub - Control Center", 50, 50);
 
   // Display WiFi status
-  if (isWiFiConnected()) {
+  if (WiFi.status() == WL_CONNECTED) {
     lcd.drawString("WiFi: Connected", 50, 100);
   } else {
     lcd.drawString("WiFi: Disconnected", 50, 100);


### PR DESCRIPTION
- Remove WiFi initialization from hub_network module
- WiFi is now initialized separately in main.cpp
- Renamed initNetwork() to initHeartbeat() for clarity
- Removed isWiFiConnected() wrapper (use WiFi.status() directly)
- Made config variables static in hub_network.cpp

Benefits:
- No duplicate WiFi initialization
- Clearer separation of concerns
- WiFi can be managed independently
- Heartbeat module is now WiFi-agnostic
- Easier to reuse in different projects