### PR TITLE
Add endpoint to get all devices status for frontend

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const {
   handleHeartbeat,
   getDeviceStatus,
+  getAllDevicesStatus,
   handleSensorData,
   getDeviceHistory,
   registerDevice
@@ -23,6 +24,11 @@ router.post('/heartbeat', authenticateDevice, handleHeartbeat);
 // @desc    Receive sensor data (throttled writes)
 // @access  Private (requires device token)
 router.post('/sensor', authenticateDevice, handleSensorData);
+
+// @route   GET /api/v1/devices/status/all
+// @desc    Get all devices status (for frontend dashboard)
+// @access  Public
+router.get('/status/all', getAllDevicesStatus);
 
 // @route   GET /api/v1/devices/:device_id/status
 // @desc    Get current device status


### PR DESCRIPTION
- Create GET /api/v1/devices/status/all endpoint
- Returns all registered devices with online/offline status
- Includes summary stats (total, online, offline counts)
- Returns device info: type, name, last_seen, uptime, heap, RSSI, IP
- Public endpoint (no auth required) for frontend dashboard

Response format:
{
  "status": "ok", "timestamp": "2025-11-16T...", "summary": { "total": 2, "online": 1, "offline": 1 }, "devices": [ { "device_id": "db_001", "online": true, ... }, { "device_id": "hub_001", "online": false, ... } ] }

Frontend can now check all devices with single API call!