### PR TITLE
Add doorbell ring endpoint with device authentication

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -6,7 +6,8 @@ const {
   getAllDevicesStatus,
   handleSensorData,
   getDeviceHistory,
-  registerDevice
+  registerDevice,
+  handleDoorbellRing
 } = require('../controllers/devices');
 const { authenticateDevice } = require('../middleware/deviceAuth');
 
@@ -24,6 +25,11 @@ router.post('/heartbeat', authenticateDevice, handleHeartbeat);
 // @desc    Receive sensor data (throttled writes)
 // @access  Private (requires device token)
 router.post('/sensor', authenticateDevice, handleSensorData);
+
+// @route   POST /api/v1/devices/doorbell/ring
+// @desc    Receive doorbell ring event (immediately writes to Firebase for hub notification)
+// @access  Private (requires device token)
+router.post('/doorbell/ring', authenticateDevice, handleDoorbellRing);
 
 // @route   GET /api/v1/devices/status/all
 // @desc    Get all devices status (for frontend dashboard)

--- a/test-api.http
+++ b/test-api.http
@@ -69,3 +69,79 @@ Authorization: Bearer {{token}}
 ### 10. Logout
 GET {{baseUrl}}/logout
 Authorization: Bearer {{token}}
+
+###############################################################################
+### Device Endpoints
+###############################################################################
+
+@deviceBaseUrl = http://localhost:5000/api/v1/devices
+@deviceToken = YOUR_DEVICE_TOKEN_HERE
+
+### 11. Register a new device (get API token)
+POST {{deviceBaseUrl}}/register
+Content-Type: application/json
+
+{
+  "device_id": "doorbell_001",
+  "device_type": "doorbell",
+  "name": "Front Door Doorbell"
+}
+
+### 12. Send device heartbeat
+POST {{deviceBaseUrl}}/heartbeat
+Content-Type: application/json
+X-Device-Token: {{deviceToken}}
+
+{
+  "device_id": "doorbell_001",
+  "device_type": "doorbell",
+  "uptime_ms": 3600000,
+  "free_heap": 102400,
+  "wifi_rssi": -45,
+  "ip_address": "192.168.1.100"
+}
+
+### 13. Send sensor data
+POST {{deviceBaseUrl}}/sensor
+Content-Type: application/json
+X-Device-Token: {{deviceToken}}
+
+{
+  "device_id": "room_sensor_001",
+  "sensors": {
+    "temperature": 23.5,
+    "humidity": 45.2,
+    "motion": true
+  }
+}
+
+### 14. Doorbell ring event (NEW!) - Known visitor
+POST {{deviceBaseUrl}}/doorbell/ring
+Content-Type: application/json
+X-Device-Token: {{deviceToken}}
+
+{
+  "device_id": "doorbell_001",
+  "visitor_name": "John Smith",
+  "face_detected": true,
+  "image_url": "https://example.com/doorbell/capture/12345.jpg"
+}
+
+### 15. Doorbell ring event - Unknown visitor
+POST {{deviceBaseUrl}}/doorbell/ring
+Content-Type: application/json
+X-Device-Token: {{deviceToken}}
+
+{
+  "device_id": "doorbell_001",
+  "face_detected": false
+}
+
+### 16. Get all devices status (for frontend)
+GET {{deviceBaseUrl}}/status/all
+
+### 17. Get specific device status
+GET {{deviceBaseUrl}}/doorbell_001/status
+
+### 18. Get device history
+GET {{deviceBaseUrl}}/doorbell_001/history?limit=10


### PR DESCRIPTION
- Added POST /api/v1/devices/doorbell/ring endpoint
- Requires device token authentication (X-Device-Token header)
- No throttling - all doorbell rings written immediately to Firebase
- Stores events in doorbell_events collection for hub to query
- Hub can monitor events and play audio when doorbell rings
- Supports optional visitor_name, face_detected, and image_url fields
- Events include acknowledged flag for hub to track played alerts
- Updated test-api.http with doorbell endpoint examples