### PR TITLE
Remove all expand/collapse arrow buttons from cards

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -102,19 +102,19 @@ export default function DashboardPage() {
         content = <AlertsCard alerts={alerts} isExpanded={true} />;
         break;
       case 'temperature':
-        content = <TemperatureCard temperatureData={temperatureData} />;
+        content = <TemperatureCard temperatureData={temperatureData} isExpanded={true} />;
         break;
       case 'gas':
-        content = <GasReadingsCard gasReadings={gasReadings} />;
+        content = <GasReadingsCard gasReadings={gasReadings} isExpanded={true} />;
         break;
       case 'doors':
-        content = <DoorsWindowsCard doorsWindows={doorsWindows} />;
+        content = <DoorsWindowsCard doorsWindows={doorsWindows} isExpanded={true} />;
         break;
       case 'doorbell':
-        content = <DoorbellControlCard doorbellControl={doorbellControl} />;
+        content = <DoorbellControlCard doorbellControl={doorbellControl} isExpanded={true} />;
         break;
       case 'security':
-        content = <SecurityCard securityDevices={securityDevices} />;
+        content = <SecurityCard securityDevices={securityDevices} isExpanded={true} />;
         break;
       default:
         content = null;

--- a/src/components/dashboard/DoorbellControlCard.tsx
+++ b/src/components/dashboard/DoorbellControlCard.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, Camera, Mic, UserCheck, Bell } from 'lucide-react';
+import { Camera, Mic, UserCheck, Bell } from 'lucide-react';
 import type { DoorbellControl } from '@/types/dashboard';
 import { controlDoorbell } from '@/services/devices.service';
 
 interface DoorbellControlCardProps {
   doorbellControl: DoorbellControl;
+  isExpanded?: boolean;
 }
 
-export function DoorbellControlCard({ doorbellControl }: DoorbellControlCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function DoorbellControlCard({ doorbellControl, isExpanded = false }: DoorbellControlCardProps) {
   const [cameraActive, setCameraActive] = useState(doorbellControl.camera_active);
   const [micActive, setMicActive] = useState(doorbellControl.mic_active);
   const [faceRecognition, setFaceRecognition] = useState(doorbellControl.face_recognition);
@@ -45,19 +45,16 @@ export function DoorbellControlCard({ doorbellControl }: DoorbellControlCardProp
   };
 
   return (
-    <div className={`card ${expanded ? 'card-expanded' : ''}`}>
-      <div className="card-header" onClick={() => setExpanded(!expanded)}>
+    <div className="card">
+      <div className="card-header">
         <div className="card-title-group">
           <Bell size={20} />
           <h3>DOORBELL CONTROL</h3>
         </div>
-        <button className="expand-button">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </button>
       </div>
 
       <div className="card-content">
-        {!expanded ? (
+        {!isExpanded ? (
           /* Compact view */
           <div className="doorbell-compact">
             <div className="doorbell-status-grid">

--- a/src/components/dashboard/DoorsWindowsCard.tsx
+++ b/src/components/dashboard/DoorsWindowsCard.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, DoorOpen, DoorClosed, Lock, Unlock, Battery } from 'lucide-react';
+import React from 'react';
+import { DoorOpen, DoorClosed, Lock, Unlock, Battery } from 'lucide-react';
 import type { DoorWindow } from '@/types/dashboard';
 
 interface DoorsWindowsCardProps {
   doorsWindows: DoorWindow[];
+  isExpanded?: boolean;
 }
 
-export function DoorsWindowsCard({ doorsWindows }: DoorsWindowsCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function DoorsWindowsCard({ doorsWindows, isExpanded = false }: DoorsWindowsCardProps) {
 
   const getStatusIcon = (item: DoorWindow) => {
     if (item.type === 'door') {
@@ -51,19 +51,16 @@ export function DoorsWindowsCard({ doorsWindows }: DoorsWindowsCardProps) {
   const windows = doorsWindows.filter(item => item.type === 'window');
 
   return (
-    <div className={`card ${expanded ? 'card-expanded' : ''}`}>
-      <div className="card-header" onClick={() => setExpanded(!expanded)}>
+    <div className="card">
+      <div className="card-header">
         <div className="card-title-group">
           <DoorClosed size={20} />
           <h3>DOORS & WINDOWS</h3>
         </div>
-        <button className="expand-button">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </button>
       </div>
 
       <div className="card-content">
-        {!expanded ? (
+        {!isExpanded ? (
           /* Compact view */
           <div className="doors-windows-compact">
             {doorsWindows.map(item => (

--- a/src/components/dashboard/GasReadingsCard.tsx
+++ b/src/components/dashboard/GasReadingsCard.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
-import { ChevronDown, ChevronUp, Wind } from 'lucide-react';
+import { Wind } from 'lucide-react';
 import type { GasReading } from '@/types/dashboard';
 
 interface GasReadingsCardProps {
   gasReadings: GasReading[];
+  isExpanded?: boolean;
 }
 
-export function GasReadingsCard({ gasReadings }: GasReadingsCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function GasReadingsCard({ gasReadings, isExpanded = false }: GasReadingsCardProps) {
   const [selectedSensor, setSelectedSensor] = useState<string | null>(null);
 
   const getStatusColor = (status: string) => {
@@ -38,19 +38,16 @@ export function GasReadingsCard({ gasReadings }: GasReadingsCardProps) {
   };
 
   return (
-    <div className={`card ${expanded ? 'card-expanded' : ''}`}>
-      <div className="card-header" onClick={() => setExpanded(!expanded)}>
+    <div className="card">
+      <div className="card-header">
         <div className="card-title-group">
           <Wind size={20} />
           <h3>GAS SENSORS</h3>
         </div>
-        <button className="expand-button">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </button>
       </div>
 
       <div className="card-content">
-        {!expanded ? (
+        {!isExpanded ? (
           /* Compact view - show current readings */
           <div className="gas-compact">
             {gasReadings.map(reading => (

--- a/src/components/dashboard/SecurityCard.tsx
+++ b/src/components/dashboard/SecurityCard.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, Shield, Lock, Unlock, Camera, Bell as AlarmIcon, Battery } from 'lucide-react';
+import React from 'react';
+import { Shield, Lock, Unlock, Camera, Bell as AlarmIcon, Battery } from 'lucide-react';
 import type { SecurityDevice } from '@/types/dashboard';
 
 interface SecurityCardProps {
   securityDevices: SecurityDevice[];
+  isExpanded?: boolean;
 }
 
-export function SecurityCard({ securityDevices }: SecurityCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function SecurityCard({ securityDevices, isExpanded = false }: SecurityCardProps) {
 
   const getDeviceIcon = (device: SecurityDevice) => {
     switch (device.type) {
@@ -45,19 +45,16 @@ export function SecurityCard({ securityDevices }: SecurityCardProps) {
   const allAlarmsArmed = alarms.every(alarm => alarm.status === 'armed');
 
   return (
-    <div className={`card ${expanded ? 'card-expanded' : ''}`}>
-      <div className="card-header" onClick={() => setExpanded(!expanded)}>
+    <div className="card">
+      <div className="card-header">
         <div className="card-title-group">
           <Shield size={20} />
           <h3>SECURITY</h3>
         </div>
-        <button className="expand-button">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </button>
       </div>
 
       <div className="card-content">
-        {!expanded ? (
+        {!isExpanded ? (
           /* Compact view */
           <div className="security-compact">
             <div className="security-overview">

--- a/src/components/dashboard/TemperatureCard.tsx
+++ b/src/components/dashboard/TemperatureCard.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
-import { ChevronDown, ChevronUp, Thermometer } from 'lucide-react';
+import { Thermometer } from 'lucide-react';
 import type { TemperatureData } from '@/types/dashboard';
 
 interface TemperatureCardProps {
   temperatureData: TemperatureData[];
+  isExpanded?: boolean;
 }
 
-export function TemperatureCard({ temperatureData }: TemperatureCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function TemperatureCard({ temperatureData, isExpanded = false }: TemperatureCardProps) {
   const [selectedRoom, setSelectedRoom] = useState<string | null>(null);
 
   // Prepare data for multi-room chart
@@ -33,19 +33,16 @@ export function TemperatureCard({ temperatureData }: TemperatureCardProps) {
   const colors = ['#FF6600', '#00FF88', '#0088FF', '#FF00FF'];
 
   return (
-    <div className={`card ${expanded ? 'card-expanded' : ''}`}>
-      <div className="card-header" onClick={() => setExpanded(!expanded)}>
+    <div className="card">
+      <div className="card-header">
         <div className="card-title-group">
           <Thermometer size={20} />
           <h3>TEMPERATURE</h3>
         </div>
-        <button className="expand-button">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </button>
       </div>
 
       <div className="card-content">
-        {!expanded ? (
+        {!isExpanded ? (
           /* Compact view - show current temps */
           <div className="temperature-compact">
             <div className="temp-grid">


### PR DESCRIPTION
- Remove ChevronDown and ChevronUp imports from all card components
- Remove internal expanded state management
- Remove expand button elements from card headers
- Remove onClick handlers from card headers
- Add isExpanded prop to all card components
- Pass isExpanded={true} to all cards in modal view
- Cards now only expand via eye icon or card click

Updated components:
- TemperatureCard
- GasReadingsCard
- DoorsWindowsCard
- DoorbellControlCard
- SecurityCard