### PR TITLE
Separate doorbell ring and face detection endpoints

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -7,7 +7,8 @@ const {
   handleSensorData,
   getDeviceHistory,
   registerDevice,
-  handleDoorbellRing
+  handleDoorbellRing,
+  handleFaceDetection
 } = require('../controllers/devices');
 const { authenticateDevice } = require('../middleware/deviceAuth');
 
@@ -27,9 +28,14 @@ router.post('/heartbeat', authenticateDevice, handleHeartbeat);
 router.post('/sensor', authenticateDevice, handleSensorData);
 
 // @route   POST /api/v1/devices/doorbell/ring
-// @desc    Receive doorbell ring event (immediately writes to Firebase for hub notification)
+// @desc    Receive doorbell ring event (notify hub, no Firebase save)
 // @access  Private (requires device token)
 router.post('/doorbell/ring', authenticateDevice, handleDoorbellRing);
+
+// @route   POST /api/v1/devices/doorbell/face-detection
+// @desc    Receive face detection event from doorbell camera (saves to Firebase)
+// @access  Private (requires device token)
+router.post('/doorbell/face-detection', authenticateDevice, handleFaceDetection);
 
 // @route   GET /api/v1/devices/status/all
 // @desc    Get all devices status (for frontend dashboard)

--- a/test-api.http
+++ b/test-api.http
@@ -115,33 +115,44 @@ X-Device-Token: {{deviceToken}}
   }
 }
 
-### 14. Doorbell ring event (NEW!) - Known visitor
+### 14. Doorbell ring event (notify hub, no Firebase save)
 POST {{deviceBaseUrl}}/doorbell/ring
 Content-Type: application/json
 X-Device-Token: {{deviceToken}}
 
 {
-  "device_id": "doorbell_001",
-  "visitor_name": "John Smith",
-  "face_detected": true,
-  "image_url": "https://example.com/doorbell/capture/12345.jpg"
+  "device_id": "doorbell_001"
 }
 
-### 15. Doorbell ring event - Unknown visitor
-POST {{deviceBaseUrl}}/doorbell/ring
+### 15. Face detection event (saves to Firebase with image & name)
+POST {{deviceBaseUrl}}/doorbell/face-detection
 Content-Type: application/json
 X-Device-Token: {{deviceToken}}
 
 {
   "device_id": "doorbell_001",
-  "face_detected": false
+  "name": "John Smith",
+  "confidence": 0.95,
+  "image": "data:image/jpeg;base64,/9j/4AAQSkZJRg...",
+  "timestamp": 1699999999000
 }
 
-### 16. Get all devices status (for frontend)
+### 16. Face detection event - Unknown person
+POST {{deviceBaseUrl}}/doorbell/face-detection
+Content-Type: application/json
+X-Device-Token: {{deviceToken}}
+
+{
+  "device_id": "doorbell_001",
+  "confidence": 0.45,
+  "image": "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+}
+
+### 17. Get all devices status (for frontend)
 GET {{deviceBaseUrl}}/status/all
 
-### 17. Get specific device status
+### 18. Get specific device status
 GET {{deviceBaseUrl}}/doorbell_001/status
 
-### 18. Get device history
+### 19. Get device history
 GET {{deviceBaseUrl}}/doorbell_001/history?limit=10


### PR DESCRIPTION
- Modified /doorbell/ring to NOT save to Firebase (saves space)
- Ring endpoint now just acknowledges the event for hub notification
- Added new /doorbell/face-detection endpoint that DOES save to Firebase
- Face detection stores: image, name, confidence, timestamp
- Face detections saved in face_detections collection
- Updated test-api.http with examples for both endpoints