### PR TITLE
Add MQTT publish for instant doorbell ring notifications

### DIFF
--- a/include/doorbell_mqtt.h
+++ b/include/doorbell_mqtt.h
@@ -1,0 +1,21 @@
+#ifndef DOORBELL_MQTT_H
+#define DOORBELL_MQTT_H
+
+#include <PubSubClient.h>
+
+// Initialize MQTT client for doorbell
+void initDoorbellMQTT(const char* deviceId);
+
+// Connect to MQTT broker (call after WiFi is connected)
+bool connectDoorbellMQTT();
+
+// Publish doorbell ring event to MQTT
+void publishDoorbellRing();
+
+// Process MQTT (maintains connection, call in loop)
+void processDoorbellMQTT();
+
+// Check if MQTT is connected
+bool isDoorbellMQTTConnected();
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 	-D CONFIG_ASYNC_TCP_QUEUE_SIZE=64
 	-D CONFIG_ASYNC_TCP_RUNNING_CORE=1
 	-D CONFIG_ASYNC_TCP_STACK_SIZE=4096
-lib_deps = 
+lib_deps =
 	arkhipenko/TaskScheduler@^4.0.0
 	bblanchon/ArduinoJson@^7.4.2
 	WiFi
@@ -31,3 +31,4 @@ lib_deps =
 	adafruit/Adafruit PN532@^1.3.4
 	esp32async/ESPAsyncWebServer@^3.8.1
 	esp32async/AsyncTCP@^3.4.9
+	knolleary/PubSubClient@^2.8

--- a/src/doorbell_mqtt.cpp
+++ b/src/doorbell_mqtt.cpp
@@ -1,0 +1,110 @@
+#include "doorbell_mqtt.h"
+#include <WiFi.h>
+
+// MQTT Configuration (HiveMQ Public Broker)
+const char* MQTT_SERVER = "broker.hivemq.com";
+const int MQTT_PORT = 1883;
+
+// MQTT Topics
+const char* TOPIC_DOORBELL_RING = "smarthome/doorbell/ring";
+
+// Global MQTT objects
+WiFiClient wifiClient;
+PubSubClient mqttClient(wifiClient);
+
+// Device ID storage
+static String doorbellDeviceId = "";
+
+// ============================================================================
+// Initialize MQTT Client for Doorbell
+// ============================================================================
+void initDoorbellMQTT(const char* deviceId) {
+  doorbellDeviceId = String(deviceId);
+
+  mqttClient.setServer(MQTT_SERVER, MQTT_PORT);
+
+  Serial.println("[MQTT] Doorbell MQTT Initialized");
+  Serial.printf("  Broker: %s:%d\n", MQTT_SERVER, MQTT_PORT);
+  Serial.printf("  Device ID: %s\n", doorbellDeviceId.c_str());
+  Serial.printf("  Publish Topic: %s\n", TOPIC_DOORBELL_RING);
+}
+
+// ============================================================================
+// Connect to MQTT Broker
+// ============================================================================
+bool connectDoorbellMQTT() {
+  if (mqttClient.connected()) {
+    return true;
+  }
+
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("[MQTT] WiFi not connected");
+    return false;
+  }
+
+  Serial.printf("[MQTT] Connecting to broker %s...\n", MQTT_SERVER);
+
+  // Create unique client ID
+  String clientId = "doorbell_" + doorbellDeviceId;
+
+  // Attempt to connect
+  if (mqttClient.connect(clientId.c_str())) {
+    Serial.println("[MQTT] ✓ Connected!");
+    return true;
+  } else {
+    Serial.printf("[MQTT] ✗ Connection failed, rc=%d\n", mqttClient.state());
+    return false;
+  }
+}
+
+// ============================================================================
+// Publish doorbell ring event
+// ============================================================================
+void publishDoorbellRing() {
+  if (!mqttClient.connected()) {
+    Serial.println("[MQTT] Not connected - attempting to reconnect before publish");
+    if (!connectDoorbellMQTT()) {
+      Serial.println("[MQTT] ✗ Failed to publish - no connection");
+      return;
+    }
+  }
+
+  // Create JSON payload with device ID and timestamp
+  String payload = "{\"device_id\":\"" + doorbellDeviceId + "\",\"timestamp\":" + String(millis()) + "}";
+
+  // Publish to topic
+  bool success = mqttClient.publish(TOPIC_DOORBELL_RING, payload.c_str());
+
+  if (success) {
+    Serial.println("[MQTT] ✓ Doorbell ring published!");
+    Serial.printf("  Topic: %s\n", TOPIC_DOORBELL_RING);
+    Serial.printf("  Payload: %s\n", payload.c_str());
+  } else {
+    Serial.println("[MQTT] ✗ Failed to publish doorbell ring");
+  }
+}
+
+// ============================================================================
+// Process MQTT (maintains connection, call in loop)
+// ============================================================================
+void processDoorbellMQTT() {
+  if (!mqttClient.connected()) {
+    // Try to reconnect periodically
+    static unsigned long lastReconnectAttempt = 0;
+    unsigned long now = millis();
+
+    if (now - lastReconnectAttempt > 5000) {
+      lastReconnectAttempt = now;
+      connectDoorbellMQTT();
+    }
+  } else {
+    mqttClient.loop();
+  }
+}
+
+// ============================================================================
+// Check if MQTT is connected
+// ============================================================================
+bool isDoorbellMQTTConnected() {
+  return mqttClient.connected();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "slave_state_manager.h"
 #include "weather.h"
 #include "heartbeat.h"
+#include "doorbell_mqtt.h"
 #include <TJpg_Decoder.h>
 #include <cstring>
 #include <esp_system.h>
@@ -162,6 +163,7 @@ Task taskCheckButtons(10, TASK_FOREVER, &checkButtons);                       //
 Task taskCheckSlaveSync(1000, TASK_FOREVER, &checkSlaveSyncTask);             // Check slave mode sync and recovery every 1s
 Task taskUpdateWeather(1800000, TASK_FOREVER, &updateWeather);                // Update weather every 30 minutes (1800000ms)
 Task taskSendServerHeartbeat(60000, TASK_FOREVER, &sendServerHeartbeatTask);  // Send heartbeat to server every 60s
+Task taskProcessDoorbellMQTT(100, TASK_FOREVER, &processDoorbellMQTT);        // Process MQTT connection every 100ms
 
 void setup()
 {
@@ -265,6 +267,11 @@ void setup()
   );
   Serial.println("[MAIN] Heartbeat module initialized");
 
+  // Initialize MQTT client (WiFi already initialized by heartbeat module)
+  initDoorbellMQTT("db_001");  // Same device ID as heartbeat
+  connectDoorbellMQTT();
+  Serial.println("[MAIN] MQTT client initialized - will publish doorbell rings");
+
   // Configure TJpg_Decoder
   TJpgDec.setCallback(tft_jpg_render_callback); // Set the callback
   TJpgDec.setJpgScale(1);                       // Full resolution
@@ -290,6 +297,7 @@ void setup()
   myscheduler.addTask(taskUpdateWeather);
   myscheduler.addTask(taskSendServerHeartbeat);
   myscheduler.addTask(taskCheckTimers);
+  myscheduler.addTask(taskProcessDoorbellMQTT);
   taskCheckUART.enable();
   taskCheckUART2.enable();
   taskSendPing.enable();
@@ -306,6 +314,7 @@ void setup()
   taskUpdateWeather.enable();
   taskSendServerHeartbeat.enable();
   taskCheckTimers.enable();
+  taskProcessDoorbellMQTT.enable();
 
   last_pong_time = millis();
   last_amp_pong_time = millis();
@@ -1225,8 +1234,11 @@ void updateButtonState(ButtonState &btn, int pin, const char *buttonName)
           updateStatusMsg("Ringing...", true, oldStatus.c_str());
           sendUART2Command("play", "doorbell");
 
-          // Send doorbell ring event to backend (hub will be notified)
+          // Send doorbell ring event to backend (for logging to Firebase)
           sendDoorbellRing();
+
+          // Publish to MQTT for instant hub notification
+          publishDoorbellRing();
         }
         else if (strcmp(buttonName, "Call") == 0)
         {


### PR DESCRIPTION
- Add PubSubClient MQTT library to platformio.ini
- Create doorbell_mqtt module for publishing ring events
- Publish to smarthome/doorbell/ring topic when button pressed
- Doorbell now sends both HTTP POST (for Firebase logging) and MQTT (for instant hub notification)
- Add MQTT processing task to maintain connection

Flow:
  Button Press → HTTP POST to backend (logs to Firebase) + MQTT publish → Hub receives instantly

MQTT Broker: broker.hivemq.com:1883 (HiveMQ Public)
Device ID: db_001