### PR TITLE
Add face detection MQTT subscription and error logging to Hub

### DIFF
--- a/include/hub_network.h
+++ b/include/hub_network.h
@@ -30,4 +30,7 @@ DeviceStatus checkDoorbellStatus();
 // Get last heartbeat status
 bool getLastHeartbeatSuccess();
 
+// Send log/error to backend
+void sendLogToBackend(const char* level, const char* message, const char* data = nullptr);
+
 #endif

--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -4,11 +4,12 @@
 #include <Arduino.h>
 #include <PubSubClient.h>
 
-// MQTT callback function type for doorbell ring
+// MQTT callback function types
 typedef void (*MqttDoorbellCallback)();
+typedef void (*MqttFaceDetectionCallback)(bool recognized, const char* name, float confidence);
 
 // Initialize MQTT client
-void initMQTT(const char* clientId, MqttDoorbellCallback doorbellCallback);
+void initMQTT(const char* clientId, MqttDoorbellCallback doorbellCallback, MqttFaceDetectionCallback faceCallback);
 
 // Connect/reconnect to MQTT broker
 bool connectMQTT();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ void sendHeartbeatTask();
 void checkDoorbellTask();
 void processMQTTTask();
 void onDoorbellRing();
+void onFaceDetection(bool recognized, const char* name, float confidence);
 void drawWifiSymbol(int x, int y, int strength);
 
 Task taskUpdateTopBar(1000, TASK_FOREVER, &updateTopBar);
@@ -176,10 +177,10 @@ void setup(void)
   );
 
   // Initialize MQTT client (WiFi already initialized)
-  initMQTT("hub_hb_001", onDoorbellRing);
+  initMQTT("hub_hb_001", onDoorbellRing, onFaceDetection);
   connectMQTT(); // Initial connection attempt
 
-  Serial.println("[MQTT] Hub will receive doorbell rings via MQTT (no polling!)");
+  Serial.println("[MQTT] Hub will receive doorbell rings and face detection via MQTT!");
 
   // Setup scheduler tasks
   scheduler.addTask(taskUpdateTopBar);
@@ -419,6 +420,21 @@ void onDoorbellRing()
   // TODO: Add audio playback here when audio hardware is connected
   // Example: playDoorbellSound();
   // or send command to audio module via UART/I2C
+}
+
+// Callback: Called when face detection event received (triggered by MQTT)
+void onFaceDetection(bool recognized, const char* name, float confidence)
+{
+  Serial.printf("[Hub] 👤 Face Detection via MQTT!\n");
+  Serial.printf("  Name: %s\n", name);
+  Serial.printf("  Recognized: %s\n", recognized ? "Yes" : "No");
+  Serial.printf("  Confidence: %.2f\n", confidence);
+
+  // TODO: Display face detection on screen
+  // TODO: Log to Firebase via backend
+  // TODO: Show notification based on recognized status
+
+  contentNeedsUpdate = true; // Trigger content area update
 }
 
 // Draw WiFi symbol with signal strength indicator


### PR DESCRIPTION
MQTT Face Detection:
- Add MqttFaceDetectionCallback type for face detection events
- Subscribe to smarthome/face/detection topic
- Parse JSON payload (recognized, name, confidence)
- Add onFaceDetection callback to handle face events
- Display face detection info in Serial console

Hub Error/Log Reporting:
- Add sendLogToBackend function in hub_network module
- POST to /api/v1/devices/hub/log endpoint
- Send errors, warnings, info, and debug logs to backend
- Logs saved to Firebase and visible on frontend dashboard
- Includes level, message, data, and timestamp

Architecture Flow:
  Doorbell → Face Recognition → Backend → MQTT publish → Hub receives event Hub → Errors/Logs → Backend → Firebase → Frontend Dashboard

Topics Hub subscribes to:
  - smarthome/doorbell/ring: Doorbell button press
  - smarthome/face/detection: Face recognition results
  - smarthome/hub/command: Backend commands