### PR TITLE
Add image capture and transmission for face detection events

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,3 +32,4 @@ lib_deps =
 	esp32async/ESPAsyncWebServer@^3.8.1
 	esp32async/AsyncTCP@^3.4.9
 	knolleary/PubSubClient@^2.8
+	bblanchon/base64@^1.5.0

--- a/src/comm/uart_commands.cpp
+++ b/src/comm/uart_commands.cpp
@@ -1,6 +1,12 @@
 #include "uart_commands.h"
 #include "lcd_helper.h"
 #include "slave_state_manager.h"
+#include "heartbeat.h"
+#include "SPIMaster.h"
+#include <base64.hpp>
+
+// External references
+extern SPIMaster spiMaster;
 
 // Send command to Slave (with automatic mode tracking)
 void sendUARTCommand(const char *cmd, const char *param, int value)
@@ -178,6 +184,7 @@ void handleUARTResponse(String line)
       int id = data["id"] | -1;
       const char *name = data["name"] | "Unknown";
       float confidence = data["confidence"] | 0.0;
+      bool recognized = (id >= 0);
 
       Serial.printf("Face Recognized: ID=%d, Name=%s, Confidence=%.2f\n",
                     id, name, confidence);
@@ -185,8 +192,27 @@ void handleUARTResponse(String line)
       // Clear face recognition timeout (face was recognized)
       face_recognition_active = false;
 
+      // Capture last frame and convert to Base64
+      String imageBase64 = "";
+      if (spiMaster.isFrameReady())
+      {
+        uint8_t* frameData = spiMaster.getFrameData();
+        uint32_t frameSize = spiMaster.getFrameSize();
+
+        if (frameData != nullptr && frameSize > 0)
+        {
+          // Encode JPEG frame to Base64
+          imageBase64 = base64::encode(frameData, frameSize);
+          Serial.printf("[FaceDetection] Captured frame: %u bytes -> %u Base64 chars\n",
+                        frameSize, imageBase64.length());
+        }
+      }
+
+      // Send face detection event to backend (saves to Firebase + publishes to Hub via MQTT)
+      sendFaceDetection(recognized, name, confidence, imageBase64.c_str());
+
       // Update LCD status with recognition result
-      if (id >= 0)
+      if (recognized)
       {
         sendUART2Command("play", "success");
         char msg[64];


### PR DESCRIPTION
Features:
- Capture last JPEG frame when face recognition occurs
- Encode frame to Base64 using bblanchon/base64 library
- Send image with face detection data to backend
- Backend saves image to Firebase and publishes to Hub via MQTT

Implementation:
- Added base64 library to platformio.ini
- Get frame from SPIMaster when face_recognized event occurs
- Encode ~9KB JPEG to Base64 (~12KB Base64 string)
- Call sendFaceDetection() with recognized status, name, confidence, and image
- Image included in HTTP POST to /api/v1/devices/doorbell/face-detection

Flow:
  Camera recognizes face → UART event → Capture frame → Base64 encode → sendFaceDetection(recognized, name, conf, imageBase64) → Backend → Firebase + MQTT → Hub

Image stored in Firebase for frontend display and historical records.