### PR TITLE
Add multipart/form-data support for face detection image uploads

### DIFF
--- a/config/firebase.js
+++ b/config/firebase.js
@@ -16,13 +16,15 @@ const initializeFirebase = () => {
           projectId: process.env.FIREBASE_PROJECT_ID,
           privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
           clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-        })
+        }),
+        storageBucket: process.env.FIREBASE_STORAGE_BUCKET || `${process.env.FIREBASE_PROJECT_ID}.appspot.com`
       });
     } else {
       // Fallback: Use service account key file
       const serviceAccount = require('./serviceAccountKey.json');
       admin.initializeApp({
-        credential: admin.credential.cert(serviceAccount)
+        credential: admin.credential.cert(serviceAccount),
+        storageBucket: process.env.FIREBASE_STORAGE_BUCKET || `${serviceAccount.project_id}.appspot.com`
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.11.0",
     "mqtt": "^5.10.1",
+    "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9"
   },
   "devDependencies": {

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const multer = require('multer');
 const {
   handleHeartbeat,
   getDeviceStatus,
@@ -12,6 +13,14 @@ const {
   handleHubLog
 } = require('../controllers/devices');
 const { authenticateDevice } = require('../middleware/deviceAuth');
+
+// Configure multer for in-memory file storage (for face detection images)
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 500 * 1024, // 500KB max file size
+  }
+});
 
 // @route   POST /api/v1/devices/register
 // @desc    Register a new device (admin only - call manually or via secure endpoint)
@@ -36,7 +45,7 @@ router.post('/doorbell/ring', authenticateDevice, handleDoorbellRing);
 // @route   POST /api/v1/devices/doorbell/face-detection
 // @desc    Receive face detection event from doorbell camera (saves to Firebase)
 // @access  Private (requires device token)
-router.post('/doorbell/face-detection', authenticateDevice, handleFaceDetection);
+router.post('/doorbell/face-detection', authenticateDevice, upload.single('image'), handleFaceDetection);
 
 // @route   POST /api/v1/devices/hub/log
 // @desc    Receive logs and errors from Hub (saves to Firebase for frontend)


### PR DESCRIPTION
- Add multer middleware for handling binary image uploads
- Update handleFaceDetection to parse multipart form fields
- Upload images to Firebase Storage and store public URLs
- Remove Base64 encoding overhead (33% size reduction)
- Configure Firebase Storage bucket in admin initialization
- Parse form fields: device_id, recognized, name, confidence
- Extract image from req.file.buffer and upload to Storage
- Return image_url in response for verification