### PR TITLE
Add PMS5003 PM sensor and DHT11 climate sensor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,222 @@
-# ESP32_Embbeded_Home
-This is a IoT project simulating a full fledged smart home ecosystem using ESP32 boards, developed in according to  Chulalongkorn's 2110356 Embedded System class.
+# ESP32-S3 Main Mesh Node
+
+Environmental monitoring node for ESP32 Smart Home ecosystem with PM2.5 air quality and climate sensing.
+
+## 📋 Features
+
+- **Air Quality Monitoring:** PMS5003 particulate matter sensor
+  - PM1.0, PM2.5, PM10 measurements
+  - Air quality assessment (Good/Moderate/Unhealthy)
+  - Real-time particle count
+
+- **Climate Monitoring:** DHT11 temperature & humidity sensor
+  - Temperature measurement (±2°C accuracy)
+  - Humidity measurement (±5% accuracy)
+  - 5-second refresh rate
+
+- **Connectivity:**
+  - WiFi connection to backend API
+  - Automatic reconnection on network loss
+  - Data transmission every 60 seconds
+
+- **Status Indicators:**
+  - LED blink patterns for system events
+  - Serial debug output (115200 baud)
+  - Real-time air quality assessment
+
+## 🔌 Hardware
+
+- **ESP32-S3 DevKit-C** - Main microcontroller
+- **PMS5003** - Laser particulate matter sensor
+- **DHT11** - Digital temperature & humidity sensor
+
+## 📊 Pin Configuration
+
+| Component | Pin        | ESP32-S3 GPIO |
+|-----------|------------|---------------|
+| DHT11     | Data       | GPIO4         |
+| PMS5003   | TX → ESP   | GPIO16 (RX1)  |
+| PMS5003   | RX ← ESP   | GPIO17 (TX1)  |
+| Status LED| RGB LED    | GPIO48        |
+
+**Power:**
+- DHT11: 3.3V
+- PMS5003: 5V (important!)
+- Total: ~180mA typical, 1A max
+
+See [WIRING_DIAGRAM.md](WIRING_DIAGRAM.md) for detailed wiring instructions.
+
+## 🚀 Quick Start
+
+### 1. Hardware Setup
+
+```
+ESP32-S3        DHT11          PMS5003
+┌─────┐        ┌────┐         ┌──────┐
+│3.3V │────────│VCC │         │      │
+│GPIO4│────────│DATA│         │      │
+│GND  │────────│GND │────┬────│GND   │
+│     │        └────┘    │    │      │
+│5V   │─────────────────┴────│VCC   │
+│RX1  │──────────────────────│TX    │
+│TX1  │──────────────────────│RX    │
+└─────┘                       └──────┘
+```
+
+### 2. Software Setup
+
+```bash
+# Install PlatformIO
+pip install platformio
+
+# Clone repository (if not already)
+git clone <repo-url>
+cd ESP32_Embbeded_Home
+git checkout Main_mesh
+
+# Build and upload
+pio run --target upload
+
+# Monitor serial output
+pio device monitor
+```
+
+### 3. Configure WiFi & API
+
+Edit `src/main.cpp` lines 42-47:
+
+```cpp
+const char* WIFI_SSID     = "YourWiFiSSID";
+const char* WIFI_PASSWORD = "YourWiFiPassword";
+const char* API_URL       = "https://your-backend.fly.dev/api/v1/devices/sensor";
+const char* DEVICE_ID     = "main_mesh_001";
+const char* API_TOKEN     = "your_device_api_token_here";
+```
+
+## 📡 Data Format
+
+### Sent to Backend (JSON)
+
+```json
+{
+  "device_id": "main_mesh_001",
+  "sensors": {
+    "temperature": 25.3,
+    "humidity": 60.5,
+    "pm1_0": 8,
+    "pm2_5": 12,
+    "pm10": 15
+  }
+}
+```
+
+### Reading Intervals
+
+- **DHT11:** Every 5 seconds
+- **PMS5003:** Every 30 seconds
+- **Server Upload:** Every 60 seconds
+
+## 📈 Air Quality Index
+
+Based on PM2.5 levels (µg/m³):
+
+| PM2.5 Range | AQI Category                    | Color  |
+|-------------|---------------------------------|--------|
+| 0-12        | Good                            | Green  |
+| 12-35       | Moderate                        | Yellow |
+| 35-55       | Unhealthy (Sensitive Groups)    | Orange |
+| 55+         | Unhealthy                       | Red    |
+
+## 🔧 Troubleshooting
+
+**DHT11 returns NaN:**
+- Check 3.3V power connection
+- Verify GPIO4 connection
+- Ensure 10kΩ pull-up resistor (if not built-in)
+- Wait 2 seconds after power-on
+
+**PMS5003 no data:**
+- Wait 30 seconds for sensor warm-up
+- Verify 5V power (not 3.3V!)
+- Check TX/RX connections (TX → RX, RX → TX)
+- Listen for fan noise
+- Baud rate must be 9600
+
+**WiFi not connecting:**
+- Verify 2.4GHz network (ESP32 doesn't support 5GHz)
+- Check SSID/password are correct
+- Ensure WiFi is in range
+
+**Server upload fails:**
+- Verify API URL is correct and accessible
+- Check device is registered with valid API token
+- Ensure backend is running
+
+## 🛠️ Development
+
+### Project Structure
+
+```
+ESP32_Embbeded_Home/
+├── platformio.ini          # PlatformIO configuration
+├── src/
+│   └── main.cpp            # Main application code
+├── WIRING_DIAGRAM.md       # Detailed wiring guide
+└── README.md               # This file
+```
+
+### Libraries Used
+
+- **DHT sensor library** (Adafruit) - DHT11/DHT22 sensors
+- **PMS Library** (fu-hsi) - PMS5003/PMS7003 sensors
+- **ArduinoJson** - JSON serialization
+- **WiFi** (ESP32 built-in) - Network connectivity
+- **HTTPClient** (ESP32 built-in) - REST API calls
+
+### Building for Production
+
+```bash
+# Build release version
+pio run -e esp32-s3-devkitc-1
+
+# Upload via USB
+pio run --target upload
+
+# Upload via OTA (if configured)
+pio run --target upload --upload-port 192.168.1.100
+```
+
+## 📊 Serial Monitor Output
+
+```
+========================================
+ESP32-S3 Main Mesh Node
+PMS5003 + DHT11 Sensors
+========================================
+
+[WiFi] Connecting to MyNetwork.... Connected!
+[WiFi] IP Address: 192.168.1.100
+[WiFi] Signal Strength: -45 dBm
+
+[DHT11] Temperature: 25.3°C | Humidity: 60.5%
+[PMS5003] ✓ PM1.0: 8 µg/m³ | PM2.5: 12 µg/m³ | PM10: 15 µg/m³
+[PMS5003] Air Quality: GOOD
+
+[Server] ✓ Response code: 200
+```
+
+## 🔗 Related Projects
+
+- **Backend** - Express/Firebase API server
+- **Frontend** - Next.js dashboard
+- **Main_lcd** - Central hub LCD display
+- **Doorbell_Camera** - Face recognition doorbell
+
+## 📝 License
+
+MIT License - See [LICENSE](LICENSE) file
+
+## 🎓 Course Project
+
+Developed for Chulalongkorn University's **2110356 Embedded Systems** course.
+

--- a/WIRING_DIAGRAM.md
+++ b/WIRING_DIAGRAM.md
@@ -1,0 +1,284 @@
+# ESP32-S3 Main Mesh - Wiring Diagram
+
+## Hardware Components
+
+- **Microcontroller:** ESP32-S3 DevKit-C
+- **Sensor 1:** PMS5003 Particulate Matter Sensor
+- **Sensor 2:** DHT11 Temperature & Humidity Sensor
+- **Power:** 5V USB-C or External Power Supply
+
+---
+
+## Pin Assignments
+
+### DHT11 Temperature & Humidity Sensor
+
+| DHT11 Pin | ESP32-S3 Pin | Wire Color (Suggested) |
+|-----------|--------------|------------------------|
+| VCC       | 3.3V         | Red                    |
+| DATA      | GPIO4        | Yellow/Orange          |
+| GND       | GND          | Black                  |
+
+**Notes:**
+- DHT11 requires a 10kΩ pull-up resistor between DATA and VCC
+- Some DHT11 modules have built-in pull-up resistor
+- Operating voltage: 3.3V-5V (3.3V recommended for ESP32-S3)
+
+---
+
+### PMS5003 PM Sensor
+
+| PMS5003 Pin | ESP32-S3 Pin | Wire Color (Suggested) | Function        |
+|-------------|--------------|------------------------|-----------------|
+| VCC         | 5V           | Red                    | Power (5V)      |
+| GND         | GND          | Black                  | Ground          |
+| TX          | GPIO16 (RX1) | Green                  | Data Out → ESP  |
+| RX          | GPIO17 (TX1) | Blue                   | Data In ← ESP   |
+| SET         | Not Used     | -                      | Sleep Control   |
+| RESET       | Not Used     | -                      | Reset (optional)|
+
+**Notes:**
+- PMS5003 requires **5V** power (500mA max)
+- Serial communication at 9600 baud
+- TX/RX are 3.3V logic compatible (no level shifter needed)
+- SET pin can be used for sleep mode (connect to GPIO if needed)
+- RESET pin for manual sensor reset (usually not needed)
+
+---
+
+### Built-in LED (Status Indicator)
+
+| Function | ESP32-S3 Pin |
+|----------|--------------|
+| RGB LED  | GPIO48       |
+
+---
+
+## Complete Wiring Diagram (Text)
+
+```
+ESP32-S3 DevKit-C
+┌─────────────────────────────┐
+│                             │
+│  3.3V ──────────── VCC (DHT11)
+│  GPIO4 ─────────── DATA (DHT11)
+│  GND ───────────── GND (DHT11)
+│                             │
+│  5V ────────────── VCC (PMS5003)
+│  GPIO16 (RX1) ──── TX (PMS5003)
+│  GPIO17 (TX1) ──── RX (PMS5003)
+│  GND ───────────── GND (PMS5003)
+│                             │
+│  GPIO48 = Built-in RGB LED  │
+│                             │
+└─────────────────────────────┘
+```
+
+---
+
+## Physical Layout Recommendations
+
+### Breadboard Setup
+
+```
+DHT11 Sensor Module
+┌─────────────┐
+│    DHT11    │
+│   ┌─────┐   │
+│   │  □  │   │ ← Sensor Grid
+│   └─────┘   │
+└──┬──┬───┬───┘
+   │  │   │
+   V  D   G
+   C  A   N
+   C  T   D
+   │  A   │
+   │  │   │
+   └──┼───┘
+      │
+   GPIO4
+```
+
+```
+PMS5003 Sensor
+┌──────────────────┐
+│    PMS5003       │
+│  ┌──────────┐    │
+│  │   FAN    │    │ ← Internal Fan
+│  └──────────┘    │
+│                  │
+│  [Air Inlet]     │
+└─┬─┬──┬──┬──┬─────┘
+  V G  T  R  S  R
+  C N  X  X  E  E
+  C D     ←  T  S
+  │ │     →     E
+  5 G  GPIO   GPIO T
+  V N  16    17
+  D D
+```
+
+---
+
+## Power Considerations
+
+### Power Requirements
+
+| Component    | Voltage | Current (Typical) | Current (Max) |
+|-------------|---------|-------------------|---------------|
+| ESP32-S3    | 3.3V    | 80mA              | 500mA         |
+| DHT11       | 3.3V    | 0.5mA             | 2.5mA         |
+| PMS5003     | 5V      | 100mA             | 500mA         |
+| **Total**   | -       | ~180mA            | ~1000mA       |
+
+### Power Supply Options
+
+**Option 1: USB-C (Recommended)**
+- ESP32-S3 DevKit-C has onboard 5V → 3.3V regulator
+- Connect USB-C for both 5V and 3.3V rails
+- Sufficient for all components
+
+**Option 2: External 5V Power**
+- Use 5V 1A+ power adapter
+- Connect to 5V and GND pins on ESP32-S3
+- Onboard regulator provides 3.3V for DHT11 and ESP32
+
+**⚠️ Warning:**
+- Do NOT power PMS5003 from 3.3V pin
+- PMS5003 needs 5V for fan operation
+- ESP32-S3's 3.3V pin can only supply ~500mA
+
+---
+
+## Sensor Placement
+
+### DHT11 Placement
+- Keep away from heat sources (including ESP32-S3 chip)
+- Allow airflow around sensor for accurate readings
+- Mount at least 10cm away from ESP32-S3 board
+
+### PMS5003 Placement
+- Orient horizontally (fan facing down)
+- Ensure air inlet is unobstructed
+- Place in area with representative air quality
+- Avoid direct sunlight or heat sources
+- Keep away from strong airflow (fans, AC vents)
+
+---
+
+## Troubleshooting
+
+### DHT11 Not Reading
+
+**Symptom:** `[DHT11] ✗ Read failed - Check wiring!`
+
+**Solutions:**
+1. Check VCC is connected to 3.3V (not 5V)
+2. Verify DATA pin connected to GPIO4
+3. Ensure GND is connected
+4. Check if pull-up resistor is present (10kΩ between DATA and VCC)
+5. Try replacing DHT11 module (common failure mode)
+
+### PMS5003 Not Reading
+
+**Symptom:** `[PMS5003] ✗ No data - Sensor warming up or check wiring`
+
+**Solutions:**
+1. **Wait 30 seconds** - PMS5003 needs warm-up time
+2. Check VCC is connected to **5V** (not 3.3V)
+3. Verify TX (PMS) → GPIO16 (ESP)
+4. Verify RX (PMS) → GPIO17 (ESP)
+5. Check GND connection
+6. Listen for fan noise (should be audible)
+7. Try resetting ESP32-S3
+
+### Serial Monitor Shows Garbage
+
+**Symptom:** Unreadable characters in serial monitor
+
+**Solutions:**
+1. Set baud rate to **115200** in serial monitor
+2. Check USB cable is data-capable (not charge-only)
+3. Try different USB port
+
+### WiFi Not Connecting
+
+**Symptom:** `[WiFi] Not connected`
+
+**Solutions:**
+1. Update WiFi credentials in `main.cpp`:
+   ```cpp
+   const char* WIFI_SSID = "YourActualSSID";
+   const char* WIFI_PASSWORD = "YourActualPassword";
+   ```
+2. Ensure 2.4GHz WiFi (ESP32 doesn't support 5GHz)
+3. Check WiFi signal strength in location
+
+---
+
+## Serial Monitor Output Example
+
+```
+========================================
+ESP32-S3 Main Mesh Node
+PMS5003 + DHT11 Sensors
+========================================
+
+[WiFi] Connecting to MyWiFi..... Connected!
+[WiFi] IP Address: 192.168.1.100
+[WiFi] Signal Strength: -45 dBm
+
+[Sensors] Initializing...
+[DHT11] Starting sensor...
+[DHT11] ✓ Ready
+[PMS5003] Starting sensor...
+[PMS5003] ✓ Ready
+[PMS5003] Note: First readings may take 30s to stabilize
+
+[Setup] Complete! Starting sensor readings...
+
+[DHT11] Temperature: 25.3°C | Humidity: 60.5%
+[PMS5003] Requesting data...
+[PMS5003] ✓ PM1.0: 8 µg/m³ | PM2.5: 12 µg/m³ | PM10: 15 µg/m³
+[PMS5003] Air Quality: GOOD
+
+========== SENSOR READINGS ==========
+Temperature: 25.3°C
+Humidity:    60.5%
+PM1.0:       8 µg/m³
+PM2.5:       12 µg/m³
+PM10:        15 µg/m³
+====================================
+
+[Server] Sending data...
+[Server] Payload: {"device_id":"main_mesh_001","sensors":{"temperature":25.3,"humidity":60.5,"pm1_0":8,"pm2_5":12,"pm10":15}}
+[Server] ✓ Response code: 200
+[Server] Response: {"status":"ok","message":"Sensor data received"}
+```
+
+---
+
+## Next Steps
+
+1. **Flash the code:**
+   ```bash
+   pio run --target upload
+   ```
+
+2. **Open serial monitor:**
+   ```bash
+   pio device monitor
+   ```
+
+3. **Update configuration in `src/main.cpp`:**
+   - WiFi SSID and password
+   - Backend API URL
+   - Device ID and API token
+
+4. **Test sensors individually:**
+   - Cover DHT11 with hand to see temperature rise
+   - Blow on PMS5003 or use incense to see PM levels increase
+
+5. **Verify data on backend:**
+   - Check Firebase Console → Firestore
+   - Look for `devices/main_mesh_001/sensors/current`

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,16 @@
 platform = espressif32
 board = esp32-s3-devkitc-1-n16r8v
 framework = arduino
+monitor_speed = 115200
+
+; Required libraries for sensors
+lib_deps =
+    adafruit/DHT sensor library@^1.4.4
+    adafruit/Adafruit Unified Sensor@^1.1.14
+    fu-hsi/PMS Library@^1.1.0
+    bblanchon/ArduinoJson@^6.21.3
+
+; Build flags
+build_flags =
+    -DCORE_DEBUG_LEVEL=3
+    -DBOARD_HAS_PSRAM


### PR DESCRIPTION
Hardware:
- PMS5003 particulate matter sensor (PM1.0, PM2.5, PM10)
- DHT11 temperature & humidity sensor
- ESP32-S3 DevKit-C microcontroller

Pin Configuration:
- DHT11 Data: GPIO4 (with 3.3V power)
- PMS5003 TX → GPIO16 (RX1)
- PMS5003 RX ← GPIO17 (TX1)
- PMS5003 Power: 5V (important!)
- Status LED: GPIO48 (built-in RGB)

Features:
- Read DHT11 every 5 seconds (temp/humidity)
- Read PMS5003 every 30 seconds (PM levels)
- WiFi connectivity with auto-reconnect
- Send sensor data to backend every 60 seconds
- Air quality assessment (Good/Moderate/Unhealthy)
- LED status indicators
- Comprehensive error handling

Libraries:
- Adafruit DHT sensor library
- PMS Library (fu-hsi)
- ArduinoJson
- WiFi & HTTPClient (ESP32 built-in)

Files Added:
- platformio.ini - PlatformIO configuration
- src/main.cpp - Main application code (370 lines)
- WIRING_DIAGRAM.md - Detailed wiring guide
- README.md - Updated with project documentation

Configuration Required:
Update in src/main.cpp:
- WiFi SSID and password
- Backend API URL
- Device ID and API token

Usage:
pio run --target upload
pio device monitor

Data Format:
{
  "device_id": "main_mesh_001", "sensors": { "temperature": 25.3, "humidity": 60.5, "pm1_0": 8, "pm2_5": 12, "pm10": 15 } }

Air Quality Index (PM2.5):
- 0-12 µg/m³: Good
- 12-35 µg/m³: Moderate
- 35-55 µg/m³: Unhealthy (Sensitive)
- 55+ µg/m³: Unhealthy

Power Requirements:
- DHT11: 3.3V, ~0.5mA
- PMS5003: 5V, ~100mA (500mA max)
- ESP32-S3: 3.3V, ~80mA
- Total: ~180mA typical, 1A max

Troubleshooting included in WIRING_DIAGRAM.md