### PR TITLE
Add UART slave support for Main Mesh and Main Amp modules

### DIFF
--- a/include/uart_slaves.h
+++ b/include/uart_slaves.h
@@ -1,0 +1,40 @@
+#ifndef UART_SLAVES_H
+#define UART_SLAVES_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <HardwareSerial.h>
+
+// UART interfaces for slave modules
+extern HardwareSerial MeshSerial;   // Main Mesh module
+extern HardwareSerial AmpSerial;    // Main Amp module
+
+// Main Mesh ping-pong
+extern uint32_t mesh_ping_counter;
+extern unsigned long last_mesh_pong_time;
+extern int mesh_status;  // 0 = standby, -1 = disconnected, 1 = running
+
+// Main Amp ping-pong
+extern uint32_t amp_ping_counter;
+extern unsigned long last_amp_pong_time;
+extern int amp_status;  // 0 = standby, -1 = disconnected, 1 = playing
+
+// Send ping message to Main Mesh
+void sendMeshPing();
+
+// Send ping message to Main Amp
+void sendAmpPing();
+
+// Send command to Main Mesh (for future use)
+void sendMeshCommand(const char *cmd, const char *param = nullptr);
+
+// Send command to Main Amp
+void sendAmpCommand(const char *cmd, const char *url);
+
+// Handle UART response from Main Mesh
+void handleMeshResponse(String line);
+
+// Handle UART response from Main Amp
+void handleAmpResponse(String line);
+
+#endif

--- a/src/uart_slaves.cpp
+++ b/src/uart_slaves.cpp
@@ -1,0 +1,178 @@
+#include "uart_slaves.h"
+
+// UART interfaces
+HardwareSerial MeshSerial(1);  // UART1
+HardwareSerial AmpSerial(2);   // UART2
+
+// Main Mesh ping-pong state
+uint32_t mesh_ping_counter = 0;
+unsigned long last_mesh_pong_time = 0;
+int mesh_status = 0;
+
+// Main Amp ping-pong state
+uint32_t amp_ping_counter = 0;
+unsigned long last_amp_pong_time = 0;
+int amp_status = 0;
+
+// ============================================================================
+// Main Mesh UART Functions
+// ============================================================================
+
+// Send ping message to Main Mesh
+void sendMeshPing()
+{
+  JsonDocument doc;
+  doc["type"] = "ping";
+  doc["seq"] = mesh_ping_counter++;
+  doc["timestamp"] = millis();
+
+  String output;
+  serializeJson(doc, output);
+
+  MeshSerial.println(output);
+}
+
+// Send command to Main Mesh (for future expansion)
+void sendMeshCommand(const char *cmd, const char *param)
+{
+  JsonDocument doc;
+  doc["cmd"] = cmd;
+
+  if (param != nullptr)
+  {
+    doc["param"] = param;
+  }
+
+  String output;
+  serializeJson(doc, output);
+  MeshSerial.println(output);
+}
+
+// Handle UART response from Main Mesh
+void handleMeshResponse(String line)
+{
+  // Skip empty lines
+  if (line.length() == 0)
+  {
+    return;
+  }
+
+  // Parse JSON response
+  StaticJsonDocument<2048> doc;
+  DeserializationError error = deserializeJson(doc, line);
+  if (error)
+  {
+    Serial.print("[MESH] RX: ");
+    Serial.println(line);
+    Serial.print("[MESH] JSON parse error: ");
+    Serial.println(error.c_str());
+    return;
+  }
+
+  // Handle pong response (silently update timestamp)
+  if (doc.containsKey("type") && doc["type"] == "pong")
+  {
+    last_mesh_pong_time = millis();
+    return;
+  }
+
+  // Handle sensor data from mesh
+  if (doc.containsKey("source") && doc["source"] == "main_mesh")
+  {
+    Serial.println("[MESH] ✓ Received sensor data from Main Mesh");
+
+    // Extract local sensors
+    if (doc.containsKey("local_sensors"))
+    {
+      JsonObject local = doc["local_sensors"];
+      if (local.containsKey("temperature"))
+      {
+        float temp = local["temperature"];
+        float humidity = local["humidity"];
+        Serial.printf("[MESH]   Local: Temp=%.1f°C, Humidity=%.1f%%\n", temp, humidity);
+      }
+      if (local.containsKey("pm2_5"))
+      {
+        int pm25 = local["pm2_5"];
+        Serial.printf("[MESH]   Local: PM2.5=%d µg/m³\n", pm25);
+      }
+    }
+
+    // Extract mesh sensor count
+    if (doc.containsKey("mesh_node_count"))
+    {
+      int nodeCount = doc["mesh_node_count"];
+      Serial.printf("[MESH]   Mesh nodes: %d\n", nodeCount);
+    }
+
+    // TODO: Forward this data to backend or display on screen
+    return;
+  }
+
+  // Log other responses
+  Serial.print("[MESH] RX: ");
+  Serial.println(line);
+}
+
+// ============================================================================
+// Main Amp UART Functions
+// ============================================================================
+
+// Send ping message to Main Amp
+void sendAmpPing()
+{
+  JsonDocument doc;
+  doc["type"] = "ping";
+  doc["seq"] = amp_ping_counter++;
+  doc["timestamp"] = millis();
+
+  String output;
+  serializeJson(doc, output);
+
+  AmpSerial.println(output);
+}
+
+// Send command to Main Amp
+void sendAmpCommand(const char *cmd, const char *url)
+{
+  JsonDocument doc;
+  doc["cmd"] = cmd;
+  doc["url"] = url;
+
+  String output;
+  serializeJson(doc, output);
+  AmpSerial.println(output);
+}
+
+// Handle UART response from Main Amp
+void handleAmpResponse(String line)
+{
+  // Skip empty lines
+  if (line.length() == 0)
+  {
+    return;
+  }
+
+  // Parse JSON response
+  StaticJsonDocument<2048> doc;
+  DeserializationError error = deserializeJson(doc, line);
+  if (error)
+  {
+    Serial.print("[AMP] RX: ");
+    Serial.println(line);
+    Serial.print("[AMP] JSON parse error: ");
+    Serial.println(error.c_str());
+    return;
+  }
+
+  // Handle pong response (silently update timestamp)
+  if (doc.containsKey("type") && doc["type"] == "pong")
+  {
+    last_amp_pong_time = millis();
+    return;
+  }
+
+  // Handle other amp responses (for future expansion)
+  Serial.print("[AMP] RX: ");
+  Serial.println(line);
+}


### PR DESCRIPTION
Implementation:
- Added uart_slaves.h header with ping-pong protocol definitions
- Added uart_slaves.cpp with UART communication handlers
- Configured Main Mesh UART on pins 26 (RX), 25 (TX)
- Configured Main Amp UART on pins 4 (RX), 33 (TX)
- Both UARTs run at 115200 baud

Features:
- Ping-pong protocol similar to Doorbell_lcd implementation
- JSON-based message format for commands and responses
- Automatic connection status monitoring (10s timeout)
- Status indicators: -1=disconnected, 0=standby, 1=running/playing
- Auto-reconnection when pong responses resume

Tasks implemented:
- taskCheckMeshUART: Read incoming data from Main Mesh (20ms)
- taskCheckAmpUART: Read incoming data from Main Amp (20ms)
- taskSendMeshPing: Send ping to Main Mesh (1s)
- taskSendAmpPing: Send ping to Main Amp (1s)
- taskCheckMeshTimeout: Monitor Main Mesh connection (1s)
- taskCheckAmpTimeout: Monitor Main Amp connection (1s)

Display updates:
- Added Main Mesh status display (OFFLINE/STANDBY/RUNNING)
- Added Main Amp status display (OFFLINE/STANDBY/PLAYING)
- Color-coded status indicators (RED=offline, YELLOW=standby, GREEN=active)

Command support:
- Main Mesh: Receives aggregated sensor data (temperature, humidity, PM2.5)
- Main Amp: Send play/stop commands, volume control
- Both modules respond to ping with pong messages