### PR TITLE
Fix double slash in face detection API endpoint URL

### DIFF
--- a/src/heartbeat.cpp
+++ b/src/heartbeat.cpp
@@ -268,8 +268,16 @@ void sendFaceDetection(bool recognized, const char* name, float confidence, cons
   String host = (colonIdx > 0) ? serverUrl.substring(0, colonIdx) :
                 (slashIdx > 0) ? serverUrl.substring(0, slashIdx) : serverUrl;
   int port = (colonIdx > 0) ? serverUrl.substring(colonIdx + 1, (slashIdx > 0) ? slashIdx : serverUrl.length()).toInt() : 80;
-  String path = (slashIdx > 0) ? serverUrl.substring(slashIdx) : "/";
-  path += "/api/v1/devices/doorbell/face-detection";
+  String path = (slashIdx > 0) ? serverUrl.substring(slashIdx) : "";
+
+  // Ensure path starts with / but avoid double slashes
+  if (path.length() == 0 || path == "/") {
+    path = "/api/v1/devices/doorbell/face-detection";
+  } else if (path.endsWith("/")) {
+    path += "api/v1/devices/doorbell/face-detection";
+  } else {
+    path += "/api/v1/devices/doorbell/face-detection";
+  }
 
   Serial.printf("[FaceDetection] Connecting to %s:%d%s\n", host.c_str(), port, path.c_str());
 


### PR DESCRIPTION
**Problem:**
Face detection was failing with 404 error due to double slash in URL:
- Error: "Cannot POST //api/v1/devices/doorbell/face-detection"
- Root cause: When BACKEND_SERVER_URL ends with '/', path construction resulted in '//' + 'api/v1/devices/doorbell/face-detection'

**Solution:**
Updated sendFaceDetection() URL path logic to handle trailing slashes:
- If path is empty or just "/", set full path directly
- If path ends with "/", append without additional slash
- Otherwise, append with slash separator

**Test cases now handled:**
1. "embedded-smarthome.fly.dev" → "/api/v1/devices/doorbell/face-detection"
2. "embedded-smarthome.fly.dev/" → "/api/v1/devices/doorbell/face-detection"
3. "server.com/base" → "/base/api/v1/devices/doorbell/face-detection"
4. "server.com/base/" → "/base/api/v1/devices/doorbell/face-detection"

This fix ensures the face detection endpoint is always correctly formatted regardless of how BACKEND_SERVER_URL is configured.