### PR TITLE
Add backend proxy endpoints for doorbell control

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -10,7 +10,9 @@ const {
   registerDevice,
   handleDoorbellRing,
   handleFaceDetection,
-  handleHubLog
+  handleHubLog,
+  getDoorbellInfo,
+  controlDoorbell
 } = require('../controllers/devices');
 const { authenticateDevice } = require('../middleware/deviceAuth');
 
@@ -77,5 +79,15 @@ router.get('/:device_id/status', getDeviceStatus);
 // @desc    Get device history (optional)
 // @access  Public
 router.get('/:device_id/history', getDeviceHistory);
+
+// @route   GET /api/v1/devices/doorbell/:device_id/info
+// @desc    Get doorbell device info (proxies to ESP32)
+// @access  Public
+router.get('/doorbell/:device_id/info', getDoorbellInfo);
+
+// @route   POST /api/v1/devices/doorbell/:device_id/control
+// @desc    Control doorbell device (camera, mic, ping)
+// @access  Public
+router.post('/doorbell/:device_id/control', controlDoorbell);
 
 module.exports = router;


### PR DESCRIPTION
Implemented backend proxy endpoints to route frontend requests to ESP32 doorbell devices, eliminating the need for direct ESP32 communication from the frontend.

New Endpoints:
- GET /api/v1/devices/doorbell/:device_id/info
  - Retrieves doorbell status by proxying to ESP32 /info endpoint
  - Returns device IP, uptime, slave_status, wifi_rssi, etc.
  - Handles offline devices gracefully with 503 status

- POST /api/v1/devices/doorbell/:device_id/control
  - Controls doorbell functions (camera_start, camera_stop, mic_start, mic_stop, ping)
  - Validates actions against whitelist
  - Proxies commands to ESP32 device endpoints
  - Returns command execution results

Changes:
- controllers/devices.js:
  - Added getDoorbellInfo() function to proxy /info requests
  - Added controlDoorbell() function to proxy control commands
  - Retrieves device IP from Firebase before proxying
  - Comprehensive error handling for offline/unreachable devices

- routes/devices.js:
  - Registered new doorbell proxy routes
  - Imported new controller functions

Benefits:
- Centralized device communication through backend
- Frontend no longer needs direct network access to ESP32
- Better security (devices can be on private network)
- Consistent error handling and logging
- Easier to add authentication/authorization later