### PR TITLE
Add ping-pong command queue to Doorbell LCD

### DIFF
--- a/include/heartbeat.h
+++ b/include/heartbeat.h
@@ -37,4 +37,10 @@ bool sendFaceDetectionAsync(bool recognized, const char* name, float confidence,
 bool getLastHeartbeatSuccess();
 unsigned long getLastHeartbeatTime();
 
+// Ping-Pong Command Queue (NEW)
+// These functions are called automatically by sendHeartbeat() when server indicates pending commands
+void fetchAndExecuteCommands();
+bool executeCommand(String action, JsonObject params);
+void acknowledgeCommand(String commandId, bool success, String action);
+
 #endif


### PR DESCRIPTION
Implements command fetch and execution using existing heartbeat mechanism. Backend now notifies doorbell when commands are available, doorbell fetches and executes them automatically.

CHANGES:
- Updated sendHeartbeat() to parse has_pending_commands from response
- Added fetchAndExecuteCommands() to fetch commands when notified
- Added executeCommand() to handle camera, detection, and reboot commands
- Added acknowledgeCommand() to report execution status back to backend

SUPPORTED COMMANDS:
- camera_start, camera_stop
- recording_start (resume_detection), recording_stop (stop_detection)
- reboot

HOW IT WORKS:
1. Heartbeat runs every 60 seconds (taskSendServerHeartbeat)
2. Backend responds with has_pending_commands: true/false
3. If true, doorbell immediately calls fetchAndExecuteCommands()
4. Commands are executed via existing UART commands to camera module
5. Each command is acknowledged back to backend (success/failure)

This replaces the need for:
- Local HTTP control endpoints (doorbell.local)
- MQTT broker for command delivery
- Direct IP proxy from backend (which doesn't work with Fly.io)

Commands now work from anywhere via cloud backend!