### PR TITLE
Fix errno 9 "Bad file number" by calling setNoDelay after connect

### DIFF
--- a/src/face_detection_sender.cpp
+++ b/src/face_detection_sender.cpp
@@ -53,7 +53,6 @@ static void sendFaceDetectionBlocking(FaceDetectionEvent* event) {
     Serial.printf("[FaceDetectionSender] Connecting to %s:%d%s\n", host.c_str(), port, path.c_str());
 
     WiFiClient client;
-    client.setNoDelay(true);
 
     if (!client.connect(host.c_str(), port)) {
         Serial.println("[FaceDetectionSender] ✗ Connection failed");
@@ -62,6 +61,9 @@ static void sendFaceDetectionBlocking(FaceDetectionEvent* event) {
     }
 
     Serial.println("[FaceDetectionSender] ✓ Connected");
+
+    // Disable Nagle's algorithm for faster transmission (must be after connect)
+    client.setNoDelay(true);
 
     String boundary = "----ESP32Boundary" + String(millis());
 

--- a/src/heartbeat.cpp
+++ b/src/heartbeat.cpp
@@ -299,15 +299,15 @@ void sendFaceDetection(bool recognized, const char* name, float confidence, cons
 
   WiFiClient client;
 
-  // Disable Nagle's algorithm for faster transmission
-  client.setNoDelay(true);
-
   if (!client.connect(host.c_str(), port)) {
     Serial.println("[FaceDetection] ✗ Connection failed");
     return;
   }
 
   Serial.println("[FaceDetection] ✓ Connected to server");
+
+  // Disable Nagle's algorithm for faster transmission (must be after connect)
+  client.setNoDelay(true);
 
   String boundary = "----ESP32Boundary" + String(millis());
 


### PR DESCRIPTION
The setNoDelay() socket option was being called before client.connect(), which attempts to set options on an invalid file descriptor (fd = -1).

Per ESP32 documentation and common practice, socket options must be set AFTER the connection is established, not before.

Fixes:
- [WiFiClient.cpp:320] setSocketOption(): fail on -1, errno: 9, "Bad file number"
- Face detection image upload timeout issues

References:
- https://github.com/espressif/arduino-esp32/issues/2213
- https://stackoverflow.com/questions/53152590/setting-timeout-on-a-socket-using-arduino-esp32-framework