### PR TITLE
Add real-time online/offline status for doorbell and hub devices

### DIFF
--- a/src/components/dashboard/SystemStatusCard.tsx
+++ b/src/components/dashboard/SystemStatusCard.tsx
@@ -10,6 +10,10 @@ interface SystemStatusCardProps {
 export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemStatusCardProps) {
   const router = useRouter();
 
+  // Extract doorbell and hub devices from the devices array
+  const doorbellDevice = devicesStatus?.devices?.find(d => d.type === 'doorbell');
+  const hubDevice = devicesStatus?.devices?.find(d => d.type === 'hub' || d.type === 'main_lcd');
+
   const getDeviceStatusClass = (lastSeen: string | null | undefined) => {
     if (!lastSeen) return 'status-offline';
 
@@ -59,21 +63,26 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
           >
             <div className="device-status-header">
               <h3>DOORBELL</h3>
-              <span className={`status-indicator ${getDeviceStatusClass(devicesStatus?.doorbell?.last_seen)}`}>
-                {getDeviceStatusText(devicesStatus?.doorbell?.last_seen)}
+              <span className={`status-indicator ${getDeviceStatusClass(doorbellDevice?.last_seen)}`}>
+                {getDeviceStatusText(doorbellDevice?.last_seen)}
               </span>
             </div>
-            {devicesStatus?.doorbell?.last_seen && (
+            {doorbellDevice && (
               <div className="device-info">
-                <p>Last Heartbeat: {new Date(devicesStatus.doorbell.last_seen).toLocaleString()}</p>
-                <p>Device ID: {devicesStatus.doorbell.device_id || 'doorbell_001'}</p>
+                <p>Last Heartbeat: {doorbellDevice.last_seen ? new Date(doorbellDevice.last_seen).toLocaleString() : 'Never'}</p>
+                <p>Device ID: {doorbellDevice.device_id || 'N/A'}</p>
                 {isExpanded && (
                   <>
-                    <p>IP Address: 192.168.1.100</p>
-                    <p>Firmware: v2.4.1</p>
-                    <p>WiFi Signal: -45 dBm</p>
+                    <p>IP Address: {doorbellDevice.ip_address || 'N/A'}</p>
+                    <p>WiFi Signal: {doorbellDevice.wifi_rssi ? `${doorbellDevice.wifi_rssi} dBm` : 'N/A'}</p>
+                    <p>Free Heap: {doorbellDevice.free_heap ? `${(doorbellDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
                   </>
                 )}
+              </div>
+            )}
+            {!doorbellDevice && (
+              <div className="device-info">
+                <p>No doorbell device found</p>
               </div>
             )}
             <p className="device-hint">Click to configure →</p>
@@ -87,21 +96,26 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
           >
             <div className="device-status-header">
               <h3>HUB</h3>
-              <span className={`status-indicator ${getDeviceStatusClass(devicesStatus?.hub?.last_seen)}`}>
-                {getDeviceStatusText(devicesStatus?.hub?.last_seen)}
+              <span className={`status-indicator ${getDeviceStatusClass(hubDevice?.last_seen)}`}>
+                {getDeviceStatusText(hubDevice?.last_seen)}
               </span>
             </div>
-            {devicesStatus?.hub?.last_seen && (
+            {hubDevice && (
               <div className="device-info">
-                <p>Last Heartbeat: {new Date(devicesStatus.hub.last_seen).toLocaleString()}</p>
-                <p>Device ID: {devicesStatus?.hub.device_id || 'hub_001'}</p>
+                <p>Last Heartbeat: {hubDevice.last_seen ? new Date(hubDevice.last_seen).toLocaleString() : 'Never'}</p>
+                <p>Device ID: {hubDevice.device_id || 'N/A'}</p>
                 {isExpanded && (
                   <>
-                    <p>IP Address: 192.168.1.50</p>
-                    <p>Firmware: v3.2.0</p>
-                    <p>Connected Devices: 12</p>
+                    <p>IP Address: {hubDevice.ip_address || 'N/A'}</p>
+                    <p>WiFi Signal: {hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : 'N/A'}</p>
+                    <p>Free Heap: {hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
                   </>
                 )}
+              </div>
+            )}
+            {!hubDevice && (
+              <div className="device-info">
+                <p>No hub device found</p>
               </div>
             )}
             <p className="device-hint">Click to configure →</p>
@@ -114,14 +128,7 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
               <div className="health-metric">
                 <span className="metric-label">DEVICES ONLINE:</span>
                 <span className="metric-value">
-                  {[
-                    devicesStatus?.doorbell?.last_seen,
-                    devicesStatus?.hub?.last_seen
-                  ].filter(lastSeen => {
-                    if (!lastSeen) return false;
-                    const diffMinutes = (new Date().getTime() - new Date(lastSeen).getTime()) / 60000;
-                    return diffMinutes < 2;
-                  }).length} / 2
+                  {devicesStatus?.summary?.online || 0} / {devicesStatus?.summary?.total || 0}
                 </span>
               </div>
               <div className="health-metric">

--- a/src/services/devices.service.ts
+++ b/src/services/devices.service.ts
@@ -327,3 +327,45 @@ export async function getDoorbellControlStatus(deviceId: string): Promise<Doorbe
 export function findDoorbellDevice(devices: BackendDevice[]): BackendDevice | null {
   return devices.find(device => device.type === 'doorbell') || null;
 }
+
+// Helper function to find hub device from devices list
+export function findHubDevice(devices: BackendDevice[]): BackendDevice | null {
+  return devices.find(device => device.type === 'hub' || device.type === 'main_lcd') || null;
+}
+
+// Helper function to check if a device is online based on last_seen timestamp
+export function isDeviceOnline(lastSeen: string | null, thresholdMinutes: number = 2): boolean {
+  if (!lastSeen) return false;
+
+  const lastSeenDate = new Date(lastSeen);
+  const now = new Date();
+  const diffMinutes = (now.getTime() - lastSeenDate.getTime()) / 60000;
+
+  return diffMinutes < thresholdMinutes;
+}
+
+// Helper function to get device status class for styling
+export function getDeviceStatusClass(lastSeen: string | null): string {
+  if (!lastSeen) return 'status-offline';
+
+  const lastSeenDate = new Date(lastSeen);
+  const now = new Date();
+  const diffMinutes = (now.getTime() - lastSeenDate.getTime()) / 60000;
+
+  if (diffMinutes < 2) return 'status-online';
+  if (diffMinutes < 5) return 'status-warning';
+  return 'status-offline';
+}
+
+// Helper function to get human-readable device status text
+export function getDeviceStatusText(lastSeen: string | null): string {
+  if (!lastSeen) return 'OFFLINE';
+
+  const lastSeenDate = new Date(lastSeen);
+  const now = new Date();
+  const diffMinutes = Math.floor((now.getTime() - lastSeenDate.getTime()) / 60000);
+
+  if (diffMinutes < 2) return 'ONLINE';
+  if (diffMinutes < 5) return `LAST SEEN ${diffMinutes}M AGO`;
+  return 'OFFLINE';
+}


### PR DESCRIPTION
Changes:
- SystemStatusCard: Extract doorbell and hub from devices array instead of expecting them as direct properties
- SystemStatusCard: Display real device data (IP address, WiFi signal, free heap) from backend
- SystemStatusCard: Use backend summary for total online/offline count
- Doorbell page: Fetch device status from backend API and display real online/offline status
- Doorbell page: Show real device information (IP, last seen, WiFi signal, heap, uptime)
- Doorbell page: Auto-refresh status every 5 seconds
- Hub page: Fetch device status from backend API and display real online/offline status
- Hub page: Show real device information (IP, last seen, WiFi signal, heap, uptime)
- Hub page: Auto-refresh status every 5 seconds
- devices.service.ts: Add helper functions for finding devices by type
- devices.service.ts: Add helper functions for determining online status and status text

Online status logic:
- Online: Last seen within 2 minutes
- Warning: Last seen 2-5 minutes ago
- Offline: Last seen more than 5 minutes ago or never seen

All devices now poll the backend every 5 seconds to update their status in real-time.