### PR TITLE
Update device status endpoints - remove online flag, use expireAt, pr…

### DIFF
--- a/middleware/deviceAuth.js
+++ b/middleware/deviceAuth.js
@@ -25,13 +25,13 @@ const authenticateDevice = async (req, res, next) => {
       });
     }
 
-    // Get device_id from request body
-    const { device_id } = req.body;
+    // Get device_id from request body, params, or query (supports POST and GET requests)
+    const device_id = req.body?.device_id || req.params?.device_id || req.query?.device_id;
 
     if (!device_id) {
       return res.status(400).json({
         status: 'error',
-        message: 'device_id required in request body'
+        message: 'device_id required in request body, params, or query'
       });
     }
 

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -77,18 +77,18 @@ router.post('/doorbell/status', authenticateDevice, handleDoorbellStatus);
 
 // @route   GET /api/v1/devices/status/all
 // @desc    Get all devices status (for frontend dashboard)
-// @access  Public
-router.get('/status/all', getAllDevicesStatus);
+// @access  Private (requires device token)
+router.get('/status/all', authenticateDevice, getAllDevicesStatus);
 
 // @route   GET /api/v1/devices/:device_id/status
 // @desc    Get current device status
-// @access  Public
-router.get('/:device_id/status', getDeviceStatus);
+// @access  Private (requires device token)
+router.get('/:device_id/status', authenticateDevice, getDeviceStatus);
 
 // @route   GET /api/v1/devices/:device_id/history
-// @desc    Get device history (optional)
-// @access  Public
-router.get('/:device_id/history', getDeviceHistory);
+// @desc    Get device history with optional type filtering
+// @access  Private (requires device token)
+router.get('/:device_id/history', authenticateDevice, getDeviceHistory);
 
 // @route   GET /api/v1/devices/doorbell/:device_id/status
 // @desc    Get doorbell status from Firebase (data pushed by doorbell, not proxy)


### PR DESCRIPTION
…otect paths

Changes:
- getDeviceStatus: Remove online flag, return expireAt field instead
- getAllDevicesStatus: Remove online flag, use expireAt to calculate online count
- getDeviceHistory: Add type filtering (heartbeat, sensor, face_detections, logs)
- Add authentication middleware to all three GET endpoints
- Update deviceAuth middleware to support GET requests via params/query