### PR TITLE
Update frontend to use expireAt instead of online flag

### DIFF
--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -4,12 +4,12 @@ export interface Device {
   device_id: string;
   type: string;
   name: string;
-  online: boolean;
   last_seen: string | null;
   uptime_ms: number;
   free_heap: number;
   wifi_rssi: number;
   ip_address: string | null;
+  expireAt: any; // Firebase Timestamp - device is online if expireAt is in the future
 }
 
 export interface DevicesStatus {


### PR DESCRIPTION
Changes:
- Replace 'online' field with 'expireAt' in Device interface
- Update helper functions to check online status using expireAt
- Update SystemStatusCard to use new helper functions with expireAt
- Update getDeviceStatusClass and getDeviceStatusText to use expireAt