### PR TITLE
Update frontend to use online boolean from backend

### DIFF
--- a/src/components/dashboard/SystemStatusCard.tsx
+++ b/src/components/dashboard/SystemStatusCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import type { DevicesStatus } from '@/types/dashboard';
-import { isDeviceOnline, getDeviceStatusClass as getStatusClass, getDeviceStatusText as getStatusText } from '@/services/devices.service';
+import { getDeviceStatusClass as getStatusClass, getDeviceStatusText as getStatusText } from '@/services/devices.service';
 
 interface SystemStatusCardProps {
   devicesStatus: DevicesStatus | null;
@@ -15,13 +15,13 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
   const doorbellDevice = devicesStatus?.devices?.find(d => d.type === 'doorbell');
   const hubDevice = devicesStatus?.devices?.find(d => d.type === 'hub' || d.type === 'main_lcd');
 
-  // Helper functions using expireAt
-  const getDeviceStatusClass = (expireAt: any, lastSeen: string | null | undefined) => {
-    return getStatusClass(expireAt, lastSeen || null);
+  // Helper functions using online boolean from backend
+  const getDeviceStatusClass = (online: boolean, lastSeen: string | null | undefined) => {
+    return getStatusClass(online, lastSeen || null);
   };
 
-  const getDeviceStatusText = (expireAt: any, lastSeen: string | null | undefined) => {
-    return getStatusText(expireAt, lastSeen || null);
+  const getDeviceStatusText = (online: boolean, lastSeen: string | null | undefined) => {
+    return getStatusText(online, lastSeen || null);
   };
 
   const handleDoorbellClick = (e: React.MouseEvent) => {
@@ -49,8 +49,8 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
           >
             <div className="device-status-header">
               <h3>DOORBELL</h3>
-              <span className={`status-indicator ${getDeviceStatusClass(doorbellDevice?.expireAt, doorbellDevice?.last_seen)}`}>
-                {getDeviceStatusText(doorbellDevice?.expireAt, doorbellDevice?.last_seen)}
+              <span className={`status-indicator ${getDeviceStatusClass(doorbellDevice?.online || false, doorbellDevice?.last_seen)}`}>
+                {getDeviceStatusText(doorbellDevice?.online || false, doorbellDevice?.last_seen)}
               </span>
             </div>
             {doorbellDevice && (
@@ -82,8 +82,8 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
           >
             <div className="device-status-header">
               <h3>HUB</h3>
-              <span className={`status-indicator ${getDeviceStatusClass(hubDevice?.expireAt, hubDevice?.last_seen)}`}>
-                {getDeviceStatusText(hubDevice?.expireAt, hubDevice?.last_seen)}
+              <span className={`status-indicator ${getDeviceStatusClass(hubDevice?.online || false, hubDevice?.last_seen)}`}>
+                {getDeviceStatusText(hubDevice?.online || false, hubDevice?.last_seen)}
               </span>
             </div>
             {hubDevice && (

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -4,12 +4,13 @@ export interface Device {
   device_id: string;
   type: string;
   name: string;
+  online: boolean; // Computed by backend from expireAt
   last_seen: string | null;
   uptime_ms: number;
   free_heap: number;
   wifi_rssi: number;
   ip_address: string | null;
-  expireAt: any; // Firebase Timestamp - device is online if expireAt is in the future
+  expireAt: any; // Firebase Timestamp - used by backend to compute online status
 }
 
 export interface DevicesStatus {


### PR DESCRIPTION
Changes:
- Device interface: Add online boolean field (computed by backend)
- Remove isDeviceOnline helper (backend calculates it now)
- Update getDeviceStatusClass and getDeviceStatusText to use online boolean
- Update SystemStatusCard to pass online boolean instead of expireAt

The frontend now uses the online status computed by the backend instead of calculating it from expireAt on the client side.