### PR TITLE
Add MQTT command subscription for instant command execution

### DIFF
--- a/src/doorbell_mqtt.cpp
+++ b/src/doorbell_mqtt.cpp
@@ -1,5 +1,7 @@
 #include "doorbell_mqtt.h"
+#include "heartbeat.h"
 #include <WiFi.h>
+#include <ArduinoJson.h>
 
 // MQTT Configuration (HiveMQ Public Broker)
 const char* MQTT_SERVER = "broker.hivemq.com";
@@ -7,6 +9,7 @@ const int MQTT_PORT = 1883;
 
 // MQTT Topics
 const char* TOPIC_DOORBELL_RING = "smarthome/doorbell/ring";
+const char* TOPIC_DEVICE_COMMAND_TEMPLATE = "smarthome/device/%s/command"; // %s will be replaced with device ID
 
 // Global MQTT objects
 WiFiClient wifiClient;
@@ -16,17 +19,63 @@ PubSubClient mqttClient(wifiClient);
 static String doorbellDeviceId = "";
 
 // ============================================================================
+// MQTT Callback - Handles incoming messages
+// ============================================================================
+void mqttCallback(char* topic, byte* payload, unsigned int length) {
+  Serial.printf("[MQTT] Message received on topic: %s\n", topic);
+
+  // Convert payload to String
+  String message = "";
+  for (unsigned int i = 0; i < length; i++) {
+    message += (char)payload[i];
+  }
+
+  Serial.printf("[MQTT] Payload: %s\n", message.c_str());
+
+  // Parse JSON payload
+  StaticJsonDocument<512> doc;
+  DeserializationError error = deserializeJson(doc, message);
+
+  if (error) {
+    Serial.printf("[MQTT] ✗ Failed to parse JSON: %s\n", error.c_str());
+    return;
+  }
+
+  // Check if this is a command notification
+  if (doc.containsKey("fetch_commands") && doc["fetch_commands"] == true) {
+    String device_id = doc["device_id"] | "";
+    String command_id = doc["command_id"] | "";
+    String action = doc["action"] | "";
+
+    Serial.println("[MQTT] ✓ Command notification received!");
+    Serial.printf("  Device: %s\n", device_id.c_str());
+    Serial.printf("  Command ID: %s\n", command_id.c_str());
+    Serial.printf("  Action: %s\n", action.c_str());
+
+    // Fetch and execute pending commands immediately
+    Serial.println("[MQTT] → Fetching pending commands from server...");
+    fetchAndExecuteCommands();
+  }
+}
+
+// ============================================================================
 // Initialize MQTT Client for Doorbell
 // ============================================================================
 void initDoorbellMQTT(const char* deviceId) {
   doorbellDeviceId = String(deviceId);
 
   mqttClient.setServer(MQTT_SERVER, MQTT_PORT);
+  mqttClient.setCallback(mqttCallback);  // Set callback for incoming messages
 
   Serial.println("[MQTT] Doorbell MQTT Initialized");
   Serial.printf("  Broker: %s:%d\n", MQTT_SERVER, MQTT_PORT);
   Serial.printf("  Device ID: %s\n", doorbellDeviceId.c_str());
   Serial.printf("  Publish Topic: %s\n", TOPIC_DOORBELL_RING);
+
+  // Build command topic
+  char commandTopic[128];
+  snprintf(commandTopic, sizeof(commandTopic), TOPIC_DEVICE_COMMAND_TEMPLATE, doorbellDeviceId.c_str());
+  Serial.printf("  Subscribe Topic: %s\n", commandTopic);
 }
 
 // ============================================================================
@@ -50,6 +99,18 @@ bool connectDoorbellMQTT() {
   // Attempt to connect
   if (mqttClient.connect(clientId.c_str())) {
     Serial.println("[MQTT] ✓ Connected!");
+
+    // Subscribe to device-specific command topic
+    char commandTopic[128];
+    snprintf(commandTopic, sizeof(commandTopic), TOPIC_DEVICE_COMMAND_TEMPLATE, doorbellDeviceId.c_str());
+
+    bool subscribed = mqttClient.subscribe(commandTopic);
+    if (subscribed) {
+      Serial.printf("[MQTT] ✓ Subscribed to: %s\n", commandTopic);
+    } else {
+      Serial.printf("[MQTT] ✗ Failed to subscribe to: %s\n", commandTopic);
+    }
+
     return true;
   } else {
     Serial.printf("[MQTT] ✗ Connection failed, rc=%d\n", mqttClient.state());


### PR DESCRIPTION
ESP32 doorbell now subscribes to device-specific MQTT command topic for instant command notifications instead of waiting for heartbeat.

MQTT Changes:
- Subscribe to topic: 'smarthome/device/{device_id}/command'
- Add mqttCallback() to handle incoming command messages
- Parse JSON payload from backend notifications
- Immediately call fetchAndExecuteCommands() when notified

Flow:
1. Backend queues command to Firestore
2. Backend publishes MQTT notification to device topic
3. ESP32 receives MQTT message within milliseconds
4. ESP32 immediately fetches and executes pending commands
5. ESP32 acknowledges command completion

Result: Command execution latency reduced from up to 60s (heartbeat interval) to <1 second (MQTT notification + HTTP fetch).

Works in conjunction with Backend MQTT publish implementation.