### PR TITLE
Simplify slider and move WiFi button to control row

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -40,36 +40,6 @@ export default function DoorbellControlPage() {
   const [loading, setLoading] = useState(true);
   const [commandLoading, setCommandLoading] = useState<string | null>(null);
 
-  // Add custom range slider styles
-  useEffect(() => {
-    const style = document.createElement('style');
-    style.innerHTML = `
-      input[type="range"]::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 18px;
-        height: 18px;
-        border-radius: 50%;
-        background: #4CAF50;
-        cursor: pointer;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-      }
-      input[type="range"]::-moz-range-thumb {
-        width: 18px;
-        height: 18px;
-        border-radius: 50%;
-        background: #4CAF50;
-        cursor: pointer;
-        border: none;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-      }
-    `;
-    document.head.appendChild(style);
-    return () => {
-      document.head.removeChild(style);
-    };
-  }, []);
-
   // Control states
   const [cameraActive, setCameraActive] = useState(false);
   const [micActive, setMicActive] = useState(false);
@@ -495,7 +465,7 @@ export default function DoorbellControlPage() {
                       className="control-input"
                       style={{ padding: '8px', borderRadius: '4px', border: '1px solid #ddd' }}
                     />
-                    <div style={{ display: 'flex', gap: '8px' }}>
+                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
                       <button
                         className="btn-control btn-start"
                         onClick={handlePlayAmplifier}
@@ -521,100 +491,29 @@ export default function DoorbellControlPage() {
                         <RotateCw size={14} />
                         {commandLoading === 'amp_restart' ? '...' : 'RST'}
                       </button>
+                      <button
+                        className="btn-control btn-info"
+                        onClick={() => setShowWifiSettings(true)}
+                        style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '4px', fontSize: '12px' }}
+                      >
+                        <Settings size={14} />
+                        WIFI
+                      </button>
                     </div>
 
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                      <label style={{ fontSize: '13px', fontWeight: '600', color: '#555' }}>VOLUME: {ampVolume}</label>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                      <label style={{ fontSize: '13px', fontWeight: '600', color: '#555', minWidth: '80px' }}>VOLUME: {ampVolume}</label>
                       <input
                         type="range"
                         min="0"
                         max="21"
                         value={ampVolume}
                         onChange={(e) => handleVolumeChange(parseInt(e.target.value))}
-                        style={{
-                          width: '100%',
-                          height: '6px',
-                          borderRadius: '3px',
-                          background: `linear-gradient(to right, #4CAF50 0%, #4CAF50 ${(ampVolume / 21) * 100}%, #ddd ${(ampVolume / 21) * 100}%, #ddd 100%)`,
-                          outline: 'none',
-                          WebkitAppearance: 'none',
-                          cursor: 'pointer'
-                        }}
+                        style={{ flex: 1 }}
                       />
                     </div>
-
-                    <button
-                      className="btn-control btn-info"
-                      onClick={() => setShowWifiSettings(true)}
-                      style={{ fontSize: '13px', padding: '8px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
-                    >
-                      <Settings size={16} />
-                      WIFI SETTINGS
-                    </button>
                   </div>
                 </div>
-
-                {/* WiFi Settings Modal */}
-                {showWifiSettings && (
-                  <div style={{
-                    position: 'fixed',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    zIndex: 1000
-                  }}>
-                    <div style={{
-                      backgroundColor: 'white',
-                      borderRadius: '8px',
-                      padding: '24px',
-                      maxWidth: '400px',
-                      width: '90%',
-                      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
-                    }}>
-                      <h3 style={{ marginTop: 0, marginBottom: '16px', color: '#333' }}>Amplifier WiFi Settings</h3>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                        <input
-                          type="text"
-                          value={wifiSsid}
-                          onChange={(e) => setWifiSsid(e.target.value)}
-                          placeholder="WiFi SSID"
-                          className="control-input"
-                          style={{ padding: '10px', fontSize: '14px', borderRadius: '4px', border: '1px solid #ddd' }}
-                        />
-                        <input
-                          type="password"
-                          value={wifiPassword}
-                          onChange={(e) => setWifiPassword(e.target.value)}
-                          placeholder="WiFi Password"
-                          className="control-input"
-                          style={{ padding: '10px', fontSize: '14px', borderRadius: '4px', border: '1px solid #ddd' }}
-                        />
-                        <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
-                          <button
-                            className="btn-control btn-warning"
-                            onClick={handleSetAmplifierWifi}
-                            disabled={commandLoading === 'amp_wifi'}
-                            style={{ flex: 1, fontSize: '14px', padding: '10px' }}
-                          >
-                            {commandLoading === 'amp_wifi' ? 'SAVING...' : 'SAVE'}
-                          </button>
-                          <button
-                            className="btn-control"
-                            onClick={() => setShowWifiSettings(false)}
-                            style={{ flex: 1, fontSize: '14px', padding: '10px', backgroundColor: '#6c757d', borderColor: '#6c757d' }}
-                          >
-                            CANCEL
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )}
 
                 <div className="control-divider"></div>
 
@@ -763,6 +662,68 @@ export default function DoorbellControlPage() {
           </div>
         </div>
       </div>
+
+      {/* WiFi Settings Modal */}
+      {showWifiSettings && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            backgroundColor: 'white',
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '400px',
+            width: '90%',
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+          }}>
+            <h3 style={{ marginTop: 0, marginBottom: '16px', color: '#333' }}>Amplifier WiFi Settings</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <input
+                type="text"
+                value={wifiSsid}
+                onChange={(e) => setWifiSsid(e.target.value)}
+                placeholder="WiFi SSID"
+                className="control-input"
+                style={{ padding: '10px', fontSize: '14px', borderRadius: '4px', border: '1px solid #ddd' }}
+              />
+              <input
+                type="password"
+                value={wifiPassword}
+                onChange={(e) => setWifiPassword(e.target.value)}
+                placeholder="WiFi Password"
+                className="control-input"
+                style={{ padding: '10px', fontSize: '14px', borderRadius: '4px', border: '1px solid #ddd' }}
+              />
+              <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
+                <button
+                  className="btn-control btn-warning"
+                  onClick={handleSetAmplifierWifi}
+                  disabled={commandLoading === 'amp_wifi'}
+                  style={{ flex: 1, fontSize: '14px', padding: '10px' }}
+                >
+                  {commandLoading === 'amp_wifi' ? 'SAVING...' : 'SAVE'}
+                </button>
+                <button
+                  className="btn-control"
+                  onClick={() => setShowWifiSettings(false)}
+                  style={{ flex: 1, fontSize: '14px', padding: '10px', backgroundColor: '#6c757d', borderColor: '#6c757d' }}
+                >
+                  CANCEL
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </ProtectedRoute>
   );
 }


### PR DESCRIPTION
Changes:
- Remove custom slider theming (gradient/custom thumb)
- Use default browser slider styling
- Move WiFi settings button to same row as PLAY/STOP/RST
- Compact button layout with flexWrap for responsive design
- WiFi button shows Settings icon + 'WIFI' text
- Volume slider label inline with slider (horizontal layout)

URL input field preserved and working correctly.