### PR TITLE
Add mixed history display to doorbell page

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
-import { getAllDevices } from '@/services/devices.service';
+import { getAllDevices, getDeviceHistory, type HistoryEvent, type DeviceHistory } from '@/services/devices.service';
 import type { Device } from '@/types/dashboard';
 
 export default function DoorbellControlPage() {
@@ -11,6 +11,8 @@ export default function DoorbellControlPage() {
   const [doorbellDevice, setDoorbellDevice] = useState<Device | null>(null);
   const [isOnline, setIsOnline] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [history, setHistory] = useState<HistoryEvent[]>([]);
+  const [historySummary, setHistorySummary] = useState<DeviceHistory['summary'] | null>(null);
   const [settings, setSettings] = useState({
     cameraEnabled: true,
     micEnabled: true,
@@ -41,6 +43,15 @@ export default function DoorbellControlPage() {
             setIsOnline(diffMinutes < 2);
           } else {
             setIsOnline(false);
+          }
+
+          // Fetch device history
+          try {
+            const historyData = await getDeviceHistory(doorbell.device_id, 10);
+            setHistory(historyData.history);
+            setHistorySummary(historyData.summary);
+          } catch (historyError) {
+            console.error('Error fetching device history:', historyError);
           }
         }
       } catch (error) {
@@ -346,29 +357,55 @@ export default function DoorbellControlPage() {
             <div className="card">
               <div className="card-header">
                 <h3>RECENT ACTIVITY</h3>
+                {historySummary && (
+                  <span style={{ fontSize: '0.8rem', color: '#888' }}>
+                    {historySummary.total} events ({historySummary.heartbeats} status, {historySummary.face_detections} faces, {historySummary.commands} commands)
+                  </span>
+                )}
               </div>
               <div className="card-content">
                 <div className="activity-list">
-                  <div className="activity-item">
-                    <span className="activity-time">2:30 PM</span>
-                    <span className="activity-desc">Motion detected</span>
-                    <span className="activity-status status-safe">Normal</span>
-                  </div>
-                  <div className="activity-item">
-                    <span className="activity-time">11:45 AM</span>
-                    <span className="activity-desc">Doorbell pressed</span>
-                    <span className="activity-status status-safe">Delivered</span>
-                  </div>
-                  <div className="activity-item">
-                    <span className="activity-time">9:20 AM</span>
-                    <span className="activity-desc">Face recognized: John Doe</span>
-                    <span className="activity-status status-safe">Known</span>
-                  </div>
-                  <div className="activity-item">
-                    <span className="activity-time">8:00 AM</span>
-                    <span className="activity-desc">Recording started</span>
-                    <span className="activity-status status-safe">Auto</span>
-                  </div>
+                  {history.length === 0 ? (
+                    <div style={{ textAlign: 'center', padding: '20px', color: '#888' }}>
+                      No recent activity
+                    </div>
+                  ) : (
+                    history.map((event) => {
+                      const timestamp = event.timestamp?.toDate ? event.timestamp.toDate() : new Date(event.timestamp);
+                      const timeStr = timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+                      let description = '';
+                      let status = 'status-safe';
+
+                      if (event.type === 'face_detection') {
+                        const recognized = event.data.recognized;
+                        const name = event.data.name || 'Unknown';
+                        description = recognized ? `Face recognized: ${name}` : `Unknown face detected`;
+                        status = recognized ? 'status-safe' : 'status-warning';
+                      } else if (event.type === 'command') {
+                        const action = event.data.action || 'unknown';
+                        const cmdStatus = event.data.status || 'pending';
+                        description = `Command: ${action}`;
+                        status = cmdStatus === 'completed' ? 'status-safe' : cmdStatus === 'failed' ? 'status-danger' : 'status-warning';
+                      } else if (event.type === 'heartbeat') {
+                        const uptime = event.data.uptime_ms ? Math.floor(event.data.uptime_ms / 60000) : 0;
+                        description = `Status update (uptime: ${uptime}m)`;
+                        status = 'status-safe';
+                      }
+
+                      return (
+                        <div key={event.id} className="activity-item">
+                          <span className="activity-time">{timeStr}</span>
+                          <span className="activity-desc">{description}</span>
+                          <span className={`activity-status ${status}`}>
+                            {event.type === 'face_detection' ? (event.data.recognized ? 'Known' : 'Unknown') :
+                             event.type === 'command' ? (event.data.status || 'Pending') :
+                             'Online'}
+                          </span>
+                        </div>
+                      );
+                    })
+                  )}
                 </div>
               </div>
             </div>

--- a/src/services/devices.service.ts
+++ b/src/services/devices.service.ts
@@ -369,3 +369,36 @@ export function getDeviceStatusText(lastSeen: string | null): string {
   if (diffMinutes < 5) return `LAST SEEN ${diffMinutes}M AGO`;
   return 'OFFLINE';
 }
+
+// Device history interfaces
+export interface HistoryEvent {
+  type: 'heartbeat' | 'face_detection' | 'command';
+  id: string;
+  timestamp: any;
+  data: any;
+}
+
+export interface DeviceHistory {
+  status: string;
+  device_id: string;
+  summary: {
+    total: number;
+    heartbeats: number;
+    face_detections: number;
+    commands: number;
+  };
+  history: HistoryEvent[];
+}
+
+// Get device history (mixed: heartbeats, face detections, commands)
+export async function getDeviceHistory(deviceId: string, limit: number = 20): Promise<DeviceHistory> {
+  try {
+    const response = await axios.get<DeviceHistory>(
+      `${API_URL}/api/v1/devices/${deviceId}/history?limit=${limit}`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching device history:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
Updated doorbell control page to fetch and display unified device history from the new mixed history endpoint.

Changes to devices.service.ts:
- Added HistoryEvent and DeviceHistory interfaces
- Added getDeviceHistory() function to fetch mixed history
- Returns heartbeats, face detections, and commands in one timeline

Changes to doorbell/page.tsx:
- Import getDeviceHistory and history types
- Add state for history and historySummary
- Fetch device history on page load and every 5 seconds
- Replace mock activity list with real history data
- Display event counts in header (status, faces, commands)
- Format events based on type:
  * Face detections: Show recognized/unknown status with name
  * Commands: Show action and status (completed/failed/pending)
  * Heartbeats: Show uptime in minutes
- Color-code events: safe (green), warning (yellow), danger (red)
- Show "No recent activity" if history is empty

The Recent Activity section now shows:
- Real-time updates every 5 seconds
- Mixed event types sorted by timestamp
- Event type indicators
- Human-readable descriptions
- Status badges for each event

This provides users with a complete activity timeline showing all device events in one unified view.