### PR TITLE
Update frontend to handle device_state events from new backend API

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -27,7 +27,7 @@ import type { Device } from '@/types/dashboard';
 
 interface ActivityEvent {
   id: string;
-  type: 'heartbeat' | 'face_detection' | 'command';
+  type: 'heartbeat' | 'face_detection' | 'command' | 'device_state';
   timestamp: any;  // Firestore timestamp or ISO string
   data: any;
 }
@@ -397,7 +397,12 @@ export default function DoorbellControlPage() {
     }
     if (event.type === 'heartbeat') {
       const uptime = event.data?.uptime_ms ? Math.floor(event.data.uptime_ms / 60000) : 0;
-      return `Status update (uptime: ${uptime}m)`;
+      return `Heartbeat (uptime: ${uptime}m)`;
+    }
+    if (event.type === 'device_state') {
+      const ip = event.data?.ip_address || 'N/A';
+      const heap = event.data?.free_heap ? Math.floor(event.data.free_heap / 1024) : 0;
+      return `Device state (IP: ${ip}, Heap: ${heap}KB)`;
     }
     return 'Activity detected';
   };
@@ -411,6 +416,9 @@ export default function DoorbellControlPage() {
       return status.charAt(0).toUpperCase() + status.slice(1);
     }
     if (event.type === 'heartbeat') {
+      return 'Active';
+    }
+    if (event.type === 'device_state') {
       return 'Online';
     }
     return 'Event';
@@ -426,7 +434,7 @@ export default function DoorbellControlPage() {
       if (status === 'failed') return 'status-danger';
       return 'status-warning';
     }
-    if (event.type === 'heartbeat') {
+    if (event.type === 'heartbeat' || event.type === 'device_state') {
       return 'status-safe';
     }
     return 'status-safe';

--- a/src/services/devices.service.ts
+++ b/src/services/devices.service.ts
@@ -699,7 +699,7 @@ export function getDeviceStatusText(online: boolean, lastSeen: string | null): s
 
 // Device history interfaces
 export interface HistoryEvent {
-  type: 'heartbeat' | 'face_detection' | 'command';
+  type: 'heartbeat' | 'face_detection' | 'command' | 'device_state';
   id: string;
   timestamp: any;
   data: any;
@@ -710,7 +710,7 @@ export interface DeviceHistory {
   device_id: string;
   summary: {
     total: number;
-    heartbeats: number;
+    status_events: number;
     face_detections: number;
     commands: number;
   };
@@ -734,7 +734,7 @@ export async function getDeviceHistory(deviceId: string, limit: number = 20): Pr
     return {
       status: 'error',
       device_id: deviceId,
-      summary: { total: 0, heartbeats: 0, face_detections: 0, commands: 0 },
+      summary: { total: 0, status_events: 0, face_detections: 0, commands: 0 },
       history: []
     };
   }


### PR DESCRIPTION
Changes:
- Add 'device_state' to ActivityEvent type in doorbell page
- Update getActivityDescription to display device state info (IP, heap)
- Update getActivityStatus and getActivityStatusClass for device_state events
- Update HistoryEvent interface to include 'device_state' type
- Update DeviceHistory summary to use status_events instead of heartbeats
- Update error handling to match new summary structure