### PR TITLE
Configure Vercel to ONLY deploy Frontend branch

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,30 @@
+# Ignore ESP32 firmware directories
+main/
+include/
+components/
+sdkconfig
+sdkconfig.old
+CMakeLists.txt
+partitions.csv
+
+# Ignore Backend Node.js code
+controllers/
+routes/
+middleware/
+config/
+tests/
+jest.config.js
+TTL_SETUP.md
+FIRESTORE_INDEX_SETUP.md
+
+# Ignore build artifacts
+.pio/
+build/
+*.bin
+*.elf
+*.map
+
+# Ignore git and IDE files
+.git/
+.vscode/
+.idea/

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "Frontend": true
+    }
+  },
+  "github": {
+    "silent": true,
+    "autoJobCancelation": true
+  },
+  "ignoreCommand": "bash -c 'if [ \"$VERCEL_GIT_COMMIT_REF\" != \"Frontend\" ]; then echo \"Skipping build for $VERCEL_GIT_COMMIT_REF\"; exit 0; else exit 1; fi'"
+}


### PR DESCRIPTION
- deploymentEnabled only allows Frontend branch
- ignoreCommand exits early for all non-Frontend branches
- Ignores Backend, Doorbell_*, claude/*, and all other branches
- Enable silent mode and auto job cancellation
- Add .vercelignore to exclude ESP32/Backend files from builds