### PR TITLE
Improve navigation UI with ArrowLeft icon and overlay sidebar

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Camera, Mic, Volume2, RotateCw, Power, Users, Settings, Database } from 'lucide-react';
+import { Camera, Mic, Volume2, RotateCw, Power, Users, Settings, Database, ArrowLeft } from 'lucide-react';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import { getAllDevices, getDeviceHistory } from '@/services/devices.service';
 import { getCookie } from '@/utils/cookies';
@@ -573,8 +573,9 @@ export default function DoorbellControlPage() {
         <div className="dashboard-container">
           <header className="dashboard-header">
             <div className="dashboard-header-left">
-              <button className="sidebar-toggle" onClick={() => router.push('/dashboard')}>
-                ← Back
+              <button className="sidebar-toggle" onClick={() => router.push('/dashboard')} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <ArrowLeft size={20} />
+                Back
               </button>
               <h1>DOORBELL CONTROL</h1>
             </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1852,7 +1852,7 @@ h6 { font-size: var(--font-size-sm); }
   background: var(--bg-card);
   backdrop-filter: blur(20px);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
-  z-index: 50;
+  z-index: 1000;
   transition: transform var(--transition-base);
   overflow-y: auto;
   padding: var(--spacing-xl);
@@ -1982,11 +1982,11 @@ h6 { font-size: var(--font-size-sm); }
 
 .main-content {
   margin-left: 0;
-  transition: margin-left var(--transition-base);
+  transition: none;
 }
 
 .main-content.with-sidebar {
-  margin-left: 280px;
+  margin-left: 0;
 }
 
 .sidebar-overlay {
@@ -1996,7 +1996,7 @@ h6 { font-size: var(--font-size-sm); }
   width: 100vw;
   height: 100vh;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 49;
+  z-index: 999;
   display: none;
 }
 

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -13,7 +13,7 @@ import {
   getAQICategory
 } from '@/services/devices.service';
 import type { Device, HubSensorData } from '@/types/dashboard';
-import { Thermometer, Droplets, Wind, Activity, Power, RefreshCw } from 'lucide-react';
+import { Thermometer, Droplets, Wind, Activity, Power, RefreshCw, ArrowLeft } from 'lucide-react';
 
 export default function HubControlPage() {
   const router = useRouter();
@@ -102,8 +102,9 @@ export default function HubControlPage() {
         <div className="dashboard-container">
           <header className="dashboard-header">
             <div className="dashboard-header-left">
-              <button className="sidebar-toggle" onClick={() => router.push('/dashboard')}>
-                ← Back
+              <button className="sidebar-toggle" onClick={() => router.push('/dashboard')} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <ArrowLeft size={20} />
+                Back
               </button>
               <h1>HUB CONTROL</h1>
             </div>


### PR DESCRIPTION
- Replace text arrow "← Back" with ArrowLeft icon from lucide-react
- Add icon + text "Back" button with proper styling (flex layout, gap)
- Update both doorbell and hub control pages
- Change sidebar to overlay content instead of shifting it
  - Set .main-content.with-sidebar margin-left to 0
  - Remove margin-left transition for smoother experience
- Increase sidebar z-index to 1000 for proper overlay
- Increase sidebar-overlay z-index to 999
- Sidebar now slides over content instead of pushing it aside