### PR TITLE
Add sync_database command handler to ESP32

### DIFF
--- a/src/heartbeat.cpp
+++ b/src/heartbeat.cpp
@@ -929,6 +929,17 @@ bool executeCommand(String action, JsonObject params)
     sendUARTCommand("check_face_db");
     return true;
   }
+  else if (action == "sync_database") {
+    // Execute all three face database commands in sequence
+    Serial.println("[Commands] Syncing face database - executing all three commands...");
+    sendUARTCommand("face_count");
+    delay(500); // Small delay between commands
+    sendUARTCommand("check_face_db");
+    delay(500); // Small delay between commands
+    sendUARTCommand("list_faces");
+    Serial.println("[Commands] ✓ All face database commands sent");
+    return true;
+  }
 
   // System commands
   // Note: reboot/system_restart is handled specially in fetchAndExecuteCommands()


### PR DESCRIPTION
- Handle 'sync_database' action in executeCommand()
- Execute all three UART commands in sequence:
  1. face_count (get count)
  2. check_face_db (verify database)
  3. list_faces (get all faces)
- Add 500ms delays between commands to avoid overwhelming camera
- Camera responds to each, ESP32 sends results to backend
- Completes single-call sync implementation across all layers