### PR TITLE
Replace Live Camera Feed with Latest Visitors display

### DIFF
--- a/src/services/devices.service.ts
+++ b/src/services/devices.service.ts
@@ -922,3 +922,44 @@ export function getAQICategory(aqi: number): { category: string; color: string; 
   if (aqi <= 300) return { category: 'Very Unhealthy', color: '#9C27B0', status: 'status-offline' };
   return { category: 'Hazardous', color: '#880E4F', status: 'status-offline' };
 }
+
+// Visitor interface
+export interface Visitor {
+  id: string;
+  name: string;
+  image: string | null;
+  recognized: boolean;
+  confidence: number;
+  timestamp: any;
+  detected_at: any;
+}
+
+export interface LatestVisitorsResponse {
+  status: string;
+  device_id: string;
+  count: number;
+  visitors: Visitor[];
+}
+
+// Get latest visitors (face detections) with images
+export async function getLatestVisitors(deviceId: string, limit: number = 20): Promise<LatestVisitorsResponse> {
+  try {
+    const response = await axios.get<LatestVisitorsResponse>(
+      `${API_URL}/api/v1/devices/${deviceId}/visitors/latest?limit=${limit}`,
+      {
+        timeout: 10000,
+        headers: getAuthHeaders()
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching latest visitors:', error);
+    // Return empty response on error
+    return {
+      status: 'error',
+      device_id: deviceId,
+      count: 0,
+      visitors: []
+    };
+  }
+}


### PR DESCRIPTION
- Added getLatestVisitors service function to fetch 20 latest face detections
- Updated doorbell page to display Latest Visitors instead of Live Camera Feed
- Visitors displayed in responsive grid with rounded square images (100x100px)
- Shows visitor name and confidence percentage below each image
- Green border for recognized visitors, orange for unknown
- Images are fetched and refreshed every 5 seconds with device status