### PR TITLE
Update visitor modal theme and remove redundant admin labels

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -1565,8 +1565,8 @@ export default function DoorbellControlPage() {
         >
           <div
             onClick={(e) => e.stopPropagation()}
+            className="card"
             style={{
-              backgroundColor: "white",
               borderRadius: "12px",
               padding: "24px",
               maxWidth: "600px",
@@ -1705,7 +1705,6 @@ export default function DoorbellControlPage() {
                         style={{
                           fontSize: "18px",
                           fontWeight: "700",
-                          color: "#333",
                         }}
                       >
                         {(selectedVisitor.confidence * 100).toFixed(1)}%
@@ -1749,7 +1748,6 @@ export default function DoorbellControlPage() {
                     <div
                       style={{
                         fontSize: "14px",
-                        color: "#333",
                       }}
                     >
                       {selectedVisitor.detected_at

--- a/src/components/dashboard/AdminManagementCard.tsx
+++ b/src/components/dashboard/AdminManagementCard.tsx
@@ -148,14 +148,12 @@ export function AdminManagementCard({ isExpanded = false, devices = [] }: AdminM
             <div className="security-overview">
               <div className="overview-item">
                 <Users size={20} />
-                <span>ADMINS</span>
                 <span className="status-indicator">
                   {admins.length}
                 </span>
               </div>
               <div className="overview-item">
                 <User size={20} />
-                <span>USERS</span>
                 <span className="status-indicator">
                   {users.length}
                 </span>


### PR DESCRIPTION
- Updated visitor details modal to use card class for theme-aware background
- Removed hardcoded text colors to inherit from theme
- Removed redundant "ADMINS" and "USERS" labels in admin overview
- Icons alone now indicate admin/user counts clearly