### PR TITLE
Add Hub MQTT command endpoints for Main_lcd device

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -44,7 +44,11 @@ const {
   // Device info
   getDeviceInfo,
   // Visitors
-  getLatestVisitors
+  getLatestVisitors,
+  // Hub-specific
+  getHubSensors,
+  sendHubAlert,
+  getHubAmpStreaming
 } = require('../controllers/devices');
 const { authenticateDevice } = require('../middleware/deviceAuth');
 const { protect } = require('../middleware/auth');
@@ -281,5 +285,36 @@ router.get('/:device_id/info', protect, getDeviceInfo);
 // @desc    Get latest visitors (face detections) with images
 // @access  Private (requires user token)
 router.get('/:device_id/visitors/latest', protect, getLatestVisitors);
+
+// ============================================================================
+// Hub-Specific Routes
+// ============================================================================
+
+// @route   GET /api/v1/devices/:device_id/hub/sensors
+// @desc    Get Hub sensor data (DHT11 temperature/humidity + PM2.5 air quality)
+// @access  Private (requires user token)
+router.get('/:device_id/hub/sensors', protect, getHubSensors);
+
+// @route   POST /api/v1/devices/:device_id/hub/alert
+// @desc    Send alert to Hub LCD display
+// @access  Private (requires user token)
+router.post('/:device_id/hub/alert', protect, sendHubAlert);
+
+// @route   GET /api/v1/devices/:device_id/hub/amp/streaming
+// @desc    Get Hub amplifier streaming status
+// @access  Private (requires user token)
+router.get('/:device_id/hub/amp/streaming', protect, getHubAmpStreaming);
+
+// ============================================================================
+// Note: Hub also uses the following generic endpoints:
+// - POST /:device_id/amp/play - Play audio on Hub amplifier
+// - POST /:device_id/amp/stop - Stop Hub amplifier
+// - POST /:device_id/amp/restart - Restart Hub amplifier
+// - POST /:device_id/amp/volume - Set Hub amplifier volume
+// - GET  /:device_id/amp/status - Get Hub amplifier status
+// - POST /:device_id/system/restart - Restart Hub system
+// - POST /commands/pending - Hub fetches pending commands (generic)
+// - POST /commands/ack - Hub acknowledges command execution (generic)
+// ============================================================================
 
 module.exports = router;


### PR DESCRIPTION
Implemented MQTT command endpoints for Hub (Main_lcd) device with same pattern as doorbell commands. Hub can now receive commands via MQTT and respond using fetchPendingCommands/acknowledgeCommand.

New Hub-specific endpoints:
1. GET /api/v1/devices/:device_id/hub/sensors
   - Retrieve DHT11 sensor data (temperature, humidity)
   - Retrieve PM2.5 air quality sensor data
   - Returns latest sensor readings from Hub

2. POST /api/v1/devices/:device_id/hub/alert
   - Send alert messages to Hub LCD display
   - Supports alert levels: info, warning, error, critical
   - Configurable display duration (1-300 seconds)
   - Alert messages limited to 200 chars for LCD
   - Queues hub_alert command via MQTT

3. GET /api/v1/devices/:device_id/hub/amp/streaming
   - Get Hub amplifier streaming status
   - Returns: is_streaming, current_url, volume_level, is_playing
   - Useful for monitoring Hub amp state

Existing generic endpoints now documented for Hub use:
- POST /:device_id/amp/play - Play audio stream on Hub amp
- POST /:device_id/amp/stop - Stop Hub amp playback
- POST /:device_id/amp/restart - Restart Hub amplifier
- POST /:device_id/amp/volume - Set Hub amp volume (0-21)
- GET  /:device_id/amp/status - Get Hub amp status
- POST /:device_id/system/restart - Restart Hub system
- POST /commands/pending - Hub fetches pending MQTT commands
- POST /commands/ack - Hub acknowledges command execution

All endpoints use MQTT publishDeviceCommand() for immediate notification, with fallback to polling via heartbeat mechanism.

Implementation details:
- Hub sensor data expected in heartbeat/status documents
- Alert commands queued in Firestore commands collection
- MQTT notifications sent via existing publishDeviceCommand()
- All endpoints protected with user authentication
- Commands follow same pattern as doorbell (pending/completed/failed)