### PR TITLE
Fix dashboard administration card showing 0 user/admin counts

### DIFF
--- a/src/components/dashboard/AdminManagementCard.tsx
+++ b/src/components/dashboard/AdminManagementCard.tsx
@@ -35,6 +35,11 @@ export function AdminManagementCard({ isExpanded = false, devices = [] }: AdminM
 
   // Fetch admins and users on component mount
   React.useEffect(() => {
+    fetchData();
+  }, []);
+
+  // Refresh data when expanded
+  React.useEffect(() => {
     if (isExpanded) {
       fetchData();
     }


### PR DESCRIPTION
The administration card was displaying 0 for both user and admin counts in compact view because data was only fetched when the card was expanded.

Added a new useEffect hook that fetches the data immediately on component mount, ensuring counts are displayed correctly even in compact view. The existing useEffect that refreshes data on expand is kept for up-to-date info.