### PR TITLE
Display '-' for dynamic device data when offline

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ export default function DashboardPage() {
   const [devicesStatus, setDevicesStatus] = useState<DevicesStatus | null>(null);
   const [doorbellControl, setDoorbellControl] = useState<any>(null);
   const [doorbellDeviceId, setDoorbellDeviceId] = useState<string | null>(null);
+  const [doorbellOnline, setDoorbellOnline] = useState<boolean>(false);
   const [loading, setLoading] = useState(true);
   const [theme, setTheme] = useState<'purple' | 'green'>('purple');
   const [expandedCard, setExpandedCard] = useState<string | null>(null);
@@ -44,11 +45,13 @@ export default function DashboardPage() {
         const doorbellDevice = findDoorbellDevice(devices.devices);
         if (doorbellDevice) {
           setDoorbellDeviceId(doorbellDevice.device_id);
+          setDoorbellOnline(doorbellDevice.online);
           const doorbell = await getDoorbellControlStatus(doorbellDevice.device_id);
           setDoorbellControl(doorbell);
         } else {
           // No doorbell found, set default state
           setDoorbellDeviceId(null);
+          setDoorbellOnline(false);
           setDoorbellControl({
             camera_active: false,
             mic_active: false,
@@ -142,7 +145,7 @@ export default function DashboardPage() {
         content = <DoorsWindowsCard doorsWindows={doorsWindows} isExpanded={true} />;
         break;
       case 'doorbell':
-        content = <DoorbellControlCard doorbellControl={doorbellControlData} deviceId={doorbellDeviceId || undefined} isExpanded={true} />;
+        content = <DoorbellControlCard doorbellControl={doorbellControlData} deviceId={doorbellDeviceId || undefined} isOnline={doorbellOnline} isExpanded={true} />;
         break;
       case 'admin':
         content = <AdminManagementCard devices={devicesStatus?.devices || []} isExpanded={true} />;
@@ -343,7 +346,7 @@ export default function DashboardPage() {
                   <circle cx="12" cy="12" r="3"></circle>
                 </svg>
               </button>
-              <DoorbellControlCard doorbellControl={doorbellControlData} deviceId={doorbellDeviceId || undefined} />
+              <DoorbellControlCard doorbellControl={doorbellControlData} deviceId={doorbellDeviceId || undefined} isOnline={doorbellOnline} />
             </div>
 
             <div

--- a/src/components/dashboard/DoorbellControlCard.tsx
+++ b/src/components/dashboard/DoorbellControlCard.tsx
@@ -18,9 +18,10 @@ interface DoorbellControlCardProps {
   doorbellControl: DoorbellControl;
   deviceId?: string;
   isExpanded?: boolean;
+  isOnline?: boolean;
 }
 
-export function DoorbellControlCard({ doorbellControl, deviceId, isExpanded = false }: DoorbellControlCardProps) {
+export function DoorbellControlCard({ doorbellControl, deviceId, isExpanded = false, isOnline = true }: DoorbellControlCardProps) {
   const [cameraActive, setCameraActive] = useState(doorbellControl.camera_active);
   const [micActive, setMicActive] = useState(doorbellControl.mic_active);
   const [faceRecognition, setFaceRecognition] = useState(doorbellControl.face_recognition);
@@ -199,16 +200,18 @@ export function DoorbellControlCard({ doorbellControl, deviceId, isExpanded = fa
               </div>
             </div>
             <div className="doorbell-stats">
-              <p>VISITORS TODAY: {doorbellControl.visitor_count_today}</p>
+              <p>VISITORS TODAY: {isOnline ? doorbellControl.visitor_count_today : '-'}</p>
               <p>
-                LAST ACTIVITY: {doorbellControl.last_activity
-                  ? new Date(doorbellControl.last_activity).toLocaleString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit'
-                    })
-                  : 'No Activity'}
+                LAST ACTIVITY: {isOnline
+                  ? (doorbellControl.last_activity
+                      ? new Date(doorbellControl.last_activity).toLocaleString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })
+                      : 'No Activity')
+                  : '-'}
               </p>
             </div>
           </div>
@@ -379,19 +382,21 @@ export function DoorbellControlCard({ doorbellControl, deviceId, isExpanded = fa
               <div className="activity-stats">
                 <div className="stat-item">
                   <span className="stat-label">VISITORS TODAY:</span>
-                  <span className="stat-value">{doorbellControl.visitor_count_today}</span>
+                  <span className="stat-value">{isOnline ? doorbellControl.visitor_count_today : '-'}</span>
                 </div>
                 <div className="stat-item">
                   <span className="stat-label">LAST ACTIVITY:</span>
                   <span className="stat-value">
-                    {doorbellControl.last_activity
-                      ? new Date(doorbellControl.last_activity).toLocaleString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })
-                      : 'No Activity'}
+                    {isOnline
+                      ? (doorbellControl.last_activity
+                          ? new Date(doorbellControl.last_activity).toLocaleString('en-US', {
+                              month: 'short',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit'
+                            })
+                          : 'No Activity')
+                      : '-'}
                   </span>
                 </div>
                 {faceCount !== null && (

--- a/src/components/dashboard/SystemStatusCard.tsx
+++ b/src/components/dashboard/SystemStatusCard.tsx
@@ -61,9 +61,9 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
                 <p>Device ID: {doorbellDevice.device_id || 'N/A'}</p>
                 {isExpanded && (
                   <>
-                    <p>IP Address: {doorbellDevice.ip_address || 'N/A'}</p>
-                    <p>WiFi Signal: {doorbellDevice.wifi_rssi ? `${doorbellDevice.wifi_rssi} dBm` : 'N/A'}</p>
-                    <p>Free Heap: {doorbellDevice.free_heap ? `${(doorbellDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
+                    <p>IP Address: {doorbellDevice.online ? (doorbellDevice.ip_address || 'N/A') : '-'}</p>
+                    <p>WiFi Signal: {doorbellDevice.online ? (doorbellDevice.wifi_rssi ? `${doorbellDevice.wifi_rssi} dBm` : 'N/A') : '-'}</p>
+                    <p>Free Heap: {doorbellDevice.online ? (doorbellDevice.free_heap ? `${(doorbellDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A') : '-'}</p>
                   </>
                 )}
               </div>
@@ -94,9 +94,9 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
                 <p>Device ID: {hubDevice.device_id || 'N/A'}</p>
                 {isExpanded && (
                   <>
-                    <p>IP Address: {hubDevice.ip_address || 'N/A'}</p>
-                    <p>WiFi Signal: {hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : 'N/A'}</p>
-                    <p>Free Heap: {hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
+                    <p>IP Address: {hubDevice.online ? (hubDevice.ip_address || 'N/A') : '-'}</p>
+                    <p>WiFi Signal: {hubDevice.online ? (hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : 'N/A') : '-'}</p>
+                    <p>Free Heap: {hubDevice.online ? (hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A') : '-'}</p>
                   </>
                 )}
               </div>


### PR DESCRIPTION
When a device is offline, display '-' instead of stale/unreliable data for dynamic fields while preserving static information like device ID and name.

Changes:
- SystemStatusCard: Show '-' for IP Address, WiFi Signal, and Free Heap when device is offline
- DoorbellControlCard: Show '-' for Visitors Today and Last Activity when device is offline
- Dashboard: Track and pass doorbell online status to DoorbellControlCard

Static fields like Device ID, device names, and Last Heartbeat timestamp remain visible as they don't update with real-time data.