### PR TITLE
Fix hub info offline display to match doorbell pattern

### DIFF
--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -284,7 +284,7 @@ export default function HubControlPage() {
                     <div className="info-grid">
                       <div className="info-item">
                         <span className="info-label">Device ID:</span>
-                        <span className="info-value">{hubDevice.online ? hubDevice.device_id : '-'}</span>
+                        <span className="info-value">{hubDevice.device_id || 'N/A'}</span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">Status:</span>
@@ -294,34 +294,36 @@ export default function HubControlPage() {
                       </div>
                       <div className="info-item">
                         <span className="info-label">Type:</span>
-                        <span className="info-value">{hubDevice.online ? hubDevice.type : '-'}</span>
+                        <span className="info-value">{hubDevice.type || 'N/A'}</span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">IP Address:</span>
-                        <span className="info-value">{hubDevice.online ? (hubDevice.ip_address || '-') : '-'}</span>
+                        <span className="info-value">
+                          {hubDevice.online ? (hubDevice.ip_address || 'N/A') : '-'}
+                        </span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">Last Seen:</span>
                         <span className="info-value">
-                          {hubDevice.online ? (hubDevice.last_seen ? new Date(hubDevice.last_seen).toLocaleString() : '-') : '-'}
+                          {hubDevice.last_seen ? new Date(hubDevice.last_seen).toLocaleString() : 'Never'}
                         </span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">WiFi Signal:</span>
                         <span className="info-value">
-                          {hubDevice.online ? (hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : '-') : '-'}
+                          {hubDevice.online ? (hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : 'N/A') : '-'}
                         </span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">Uptime:</span>
                         <span className="info-value">
-                          {hubDevice.online ? (hubDevice.uptime_ms ? `${Math.floor(hubDevice.uptime_ms / 3600000)}h ${Math.floor((hubDevice.uptime_ms % 3600000) / 60000)}m` : '-') : '-'}
+                          {hubDevice.online ? (hubDevice.uptime_ms ? `${Math.floor(hubDevice.uptime_ms / 3600000)}h ${Math.floor((hubDevice.uptime_ms % 3600000) / 60000)}m` : 'N/A') : '-'}
                         </span>
                       </div>
                       <div className="info-item">
                         <span className="info-label">Free Heap:</span>
                         <span className="info-value">
-                          {hubDevice.online ? (hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : '-') : '-'}
+                          {hubDevice.online ? (hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A') : '-'}
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
Changes to offline state display logic:

Always show (regardless of online status):
- Device ID: Shows actual ID or 'N/A'
- Status: Shows 'Online' or 'Offline'
- Type: Shows device type or 'N/A'
- Last Seen: Shows timestamp or 'Never'

Show '-' only when offline:
- IP Address: Shows IP when online, '-' when offline
- WiFi Signal: Shows signal strength when online, '-' when offline
- Uptime: Shows uptime when online, '-' when offline
- Free Heap: Shows memory when online, '-' when offline

This matches the doorbell page pattern for consistent UX.