### PR TITLE
Add API token authentication to room sensors

### DIFF
--- a/Room_Sensor/README.md
+++ b/Room_Sensor/README.md
@@ -11,6 +11,7 @@ Battery-powered environmental sensor node for ESP32 smart home mesh network.
 - ✅ **Deep sleep** power optimization
 - ✅ **Battery monitoring** with low-power warnings
 - ✅ **Conditional transmission** (only on changes)
+- ✅ **API token authentication** for secure backend communication
 
 ### Hardware Requirements
 - ESP32-DevKitC or ESP32-S3-DevKitC
@@ -52,7 +53,20 @@ build_flags =
     -D ROOM_NAME=\"Bedroom\"                 # Change this
 ```
 
-### 4. Build and Upload
+### 4. Configure Security (API Token)
+Edit `src/main.cpp` to set your device's API token for backend authentication:
+```cpp
+// SECURITY CONFIGURATION
+const char* DEVICE_API_TOKEN = "your_secure_api_token_here";
+```
+
+**IMPORTANT:**
+- This token must match the one configured in your backend for this specific device
+- The token is sent with all mesh transmissions to authenticate with the backend
+- Keep this token secure and unique per device
+- The hub will forward this token when sending room sensor data to the backend
+
+### 5. Build and Upload
 ```bash
 # Build for default ESP32
 pio run -e esp32-room-sensor

--- a/Room_Sensor/src/main.cpp
+++ b/Room_Sensor/src/main.cpp
@@ -45,6 +45,14 @@ const char* DEVICE_TYPE = "environmental_sensor";
 const char* ROOM_NAME = "Bedroom";
 
 // ============================================================================
+// SECURITY CONFIGURATION
+// ============================================================================
+// API Token for backend authentication
+// This token is sent with sensor data to authenticate with the backend server
+// IMPORTANT: Change this to match the token configured in your backend for this device
+const char* DEVICE_API_TOKEN = "your_secure_api_token_here";
+
+// ============================================================================
 // GPIO PIN CONFIGURATION
 // ============================================================================
 #define MICS5524_HEATER_PIN  25  // Control heater power (HIGH=ON, LOW=OFF)
@@ -307,6 +315,8 @@ void setupMesh() {
 
   Serial.printf("[MESH] ✓ Node ID: %u\n", mesh.getNodeId());
   Serial.printf("[MESH] ✓ Device: %s\n", DEVICE_ID);
+  Serial.printf("[MESH] ✓ API Token: %s\n",
+                DEVICE_API_TOKEN && strlen(DEVICE_API_TOKEN) > 0 ? "***configured***" : "NOT SET");
 
   // Brief delay to allow mesh to stabilize
   delay(1000);
@@ -498,6 +508,9 @@ bool sendDataToMesh() {
   doc["device_type"] = DEVICE_TYPE;
   doc["room"] = ROOM_NAME;
   doc["boot_count"] = bootCount;
+
+  // Add API token for backend authentication
+  doc["api_token"] = DEVICE_API_TOKEN;
 
   // Add sensor data
   JsonObject data = doc.createNestedObject("data");

--- a/Room_Sensor/src/main_hybrid.cpp
+++ b/Room_Sensor/src/main_hybrid.cpp
@@ -45,6 +45,14 @@ const char* DEVICE_TYPE = "environmental_sensor";
 const char* ROOM_NAME = "Bedroom";
 
 // ============================================================================
+// SECURITY CONFIGURATION
+// ============================================================================
+// API Token for backend authentication
+// This token is sent with sensor data to authenticate with the backend server
+// IMPORTANT: Change this to match the token configured in your backend for this device
+const char* DEVICE_API_TOKEN = "your_secure_api_token_here";
+
+// ============================================================================
 // GPIO PIN CONFIGURATION
 // ============================================================================
 #define MICS5524_HEATER_PIN  25
@@ -238,6 +246,10 @@ void loop() {
   doc["device_type"] = DEVICE_TYPE;
   doc["room"] = ROOM_NAME;
   doc["boot_count"] = bootCount;
+
+  // Add API token for backend authentication
+  doc["api_token"] = DEVICE_API_TOKEN;
+
   doc["battery_voltage"] = serialized(String(currentData.batteryVoltage, 2));
   doc["battery_percent"] = currentData.batteryPercent;
 
@@ -360,6 +372,8 @@ void setupMesh() {
 
   Serial.printf("[MESH] ✓ Node ID: %u\n", mesh.getNodeId());
   Serial.printf("[MESH] ✓ Device: %s\n", DEVICE_ID);
+  Serial.printf("[MESH] ✓ API Token: %s\n",
+                DEVICE_API_TOKEN && strlen(DEVICE_API_TOKEN) > 0 ? "***configured***" : "NOT SET");
 
   delay(1000);
   mesh.update();


### PR DESCRIPTION
Implement security code feature for room sensors to authenticate with backend:
- Add DEVICE_API_TOKEN configuration constant for backend authentication
- Include api_token field in mesh transmission JSON payload
- Update both main.cpp and main_hybrid.cpp implementations
- Add security configuration logging during mesh setup
- Update README.md with API token configuration instructions

The token is sent via mesh to Main_mesh hub, which forwards it to the backend for authentication, matching the pattern used by hub and doorbell devices.