### PR TITLE
Prepare sensor data forwarding - backend endpoint needed

### DIFF
--- a/src/hub_network.cpp
+++ b/src/hub_network.cpp
@@ -278,6 +278,8 @@ void sendMeshSensorData(const char* jsonData) {
     JsonDocument doc;
     doc["device_id"] = deviceId;
     doc["device_type"] = deviceType;
+    doc["timestamp"] = millis();
+    doc["forwarded_by"] = HUB_DEVICE_ID;
 
     // Copy all sensor data (excluding api_token as it's in header)
     JsonObject data = doc.createNestedObject("data");
@@ -286,10 +288,6 @@ void sendMeshSensorData(const char* jsonData) {
         data[kv.key()] = kv.value();
       }
     }
-
-    // Add metadata
-    doc["timestamp"] = millis();
-    doc["forwarded_by"] = HUB_DEVICE_ID;
 
     String jsonString;
     serializeJson(doc, jsonString);
@@ -395,16 +393,14 @@ void sendMainMeshLocalData(const char* jsonData) {
   JsonDocument doc;
   doc["device_id"] = deviceId;
   doc["device_type"] = deviceType;
+  doc["timestamp"] = millis();
+  doc["forwarded_by"] = HUB_DEVICE_ID;
 
   // Copy all local sensor data
   JsonObject data = doc.createNestedObject("data");
   for (JsonPair kv : localSensors) {
     data[kv.key()] = kv.value();
   }
-
-  // Add metadata
-  doc["timestamp"] = millis();
-  doc["forwarded_by"] = HUB_DEVICE_ID;
 
   String jsonString;
   serializeJson(doc, jsonString);


### PR DESCRIPTION
The Main_lcd now forwards sensor data to /api/v1/devices/sensor-data endpoint. This endpoint needs to be implemented on the backend to accept sensor data.

Expected request format:
POST /api/v1/devices/sensor-data
Headers:
  Authorization: Bearer <sensor_api_token>
  Content-Type: application/json

Body:
{
  "device_id": "room_sensor_bedroom_01",
  "device_type": "environmental_sensor",
  "timestamp": 1234567890,
  "forwarded_by": "hub_device_id",
  "data": {
    "temperature": 25.5,
    "humidity": 60.0,
    "light_lux": 350.0,
    "gas_level": 1024,
    "battery_voltage": 3.7,
    "battery_percent": 85
  }
}

The backend should:
1. Validate the Bearer token against the device's configured API token
2. Store sensor data in Firebase
3. Return 200 OK with {"written": true} or {"written": false} (throttled)
4. Return 401 if authentication fails