### PR TITLE
Add /api/v1/devices/sensor-data endpoint for room sensors

### DIFF
--- a/routes/devices.js
+++ b/routes/devices.js
@@ -6,6 +6,7 @@ const {
   getDeviceStatus,
   getAllDevicesStatus,
   handleSensorData,
+  handleRoomSensorData,
   getDeviceHistory,
   registerDevice,
   handleDoorbellRing,
@@ -87,6 +88,11 @@ router.post('/heartbeat', authenticateDevice, handleHeartbeat);
 // @desc    Receive sensor data (throttled writes)
 // @access  Private (requires device token)
 router.post('/sensor', authenticateDevice, handleSensorData);
+
+// @route   POST /api/v1/devices/sensor-data
+// @desc    Receive sensor data from room sensors (forwarded by Main_lcd hub)
+// @access  Private (requires device token)
+router.post('/sensor-data', authenticateDevice, handleRoomSensorData);
 
 // @route   POST /api/v1/devices/doorbell/ring
 // @desc    Receive doorbell ring event (notify hub, no Firebase save)


### PR DESCRIPTION
Implement new endpoint to receive sensor data from room sensors forwarded by the Main_lcd hub, with individual device API token authentication.

Changes:
- controllers/devices.js:
  - Add handleRoomSensorData() function (line 314-371)
  - Accepts data format from ESP32 room sensors via Main_lcd hub
  - Validates device_id and data object
  - Uses existing shouldWriteToFirebase() throttling logic
  - Stores sensor data in Firestore devices/{device_id}/sensors/current
  - Tracks forwarded_by field to identify data source
  - Returns {written: true/false} to indicate if Firebase was updated

- routes/devices.js:
  - Add POST /sensor-data route with authenticateDevice middleware
  - Import and expose handleRoomSensorData controller

Authentication:
- Uses Bearer token authentication via authenticateDevice middleware
- Each room sensor includes its own API token
- Main_mesh local sensors use hub's API token
- Backend validates token against Firestore devices collection

Request Format:
POST /api/v1/devices/sensor-data
Headers:
  Authorization: Bearer <sensor_api_token>
  Content-Type: application/json Body:
{
  "device_id": "room_sensor_bedroom_01", "device_type": "environmental_sensor", "timestamp": 1234567890, "forwarded_by": "hub_main_001", "data": { "temperature": 25.5, "humidity": 60.0, "light_lux": 350.0, "gas_level": 1024, "battery_voltage": 3.7, "battery_percent": 85 } }

Response:
200 OK: {"status": "ok", "message": "Sensor data received", "written": true} 401: Invalid/missing token
404: Device not found

This completes the backend implementation for the room sensor security feature, working with the Main_lcd forwarding logic.