### PR TITLE
Update gas sensor card to single column width

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -271,7 +271,7 @@ export default function DashboardPage() {
               <TemperatureCard temperatureData={temperatureData} />
             </div>
 
-            {/* Row 3: 3 cards - Doors/Windows, Admin, Gas (spans 2 columns) */}
+            {/* Row 3: 3 cards - Doors/Windows, Admin, Gas (same width as other cards) */}
             <div
               className="card-row3-1"
               onClick={() => openExpandedCard('doors')}
@@ -299,7 +299,7 @@ export default function DashboardPage() {
             </div>
 
             <div
-              className="card-row3-3-span2"
+              className="card-row3-3"
               onClick={() => openExpandedCard('gas')}
             >
               <button className="card-eye-icon" onClick={(e) => { e.stopPropagation(); openExpandedCard('gas'); }}>


### PR DESCRIPTION
Changes:
- Changed Gas Sensor card className from card-row3-3-span2 to card-row3-3
- Gas sensor now has same width as Temperature card (single column)
- Updated comment to reflect new layout

Row 3 layout now has 3 equal-width cards:
- Doors/Windows (card-row3-1)
- Admin Management (card-row3-2)
- Gas Sensor (card-row3-3)

All three cards will have equal height when rendered in the same row, making Doors/Windows and Admin the same height as requested.