### PR TITLE
Update System Status popup to show all devices with battery status

### DIFF
--- a/src/components/dashboard/SystemStatusCard.tsx
+++ b/src/components/dashboard/SystemStatusCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { Battery } from 'lucide-react';
-import type { DevicesStatus } from '@/types/dashboard';
+import type { DevicesStatus, Device } from '@/types/dashboard';
 import { getDeviceStatusClass as getStatusClass, getDeviceStatusText as getStatusText } from '@/services/devices.service';
 
 interface SystemStatusCardProps {
@@ -11,10 +11,6 @@ interface SystemStatusCardProps {
 
 export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemStatusCardProps) {
   const router = useRouter();
-
-  // Extract doorbell and hub devices from the devices array
-  const doorbellDevice = devicesStatus?.devices?.find(d => d.type === 'doorbell');
-  const hubDevice = devicesStatus?.devices?.find(d => d.type === 'hub' || d.type === 'main_lcd');
 
   // Helper functions using online boolean from backend
   const getDeviceStatusClass = (online: boolean, lastSeen: string | null | undefined) => {
@@ -39,15 +35,21 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
     return 'battery-low';
   };
 
-  const handleDoorbellClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    router.push('/doorbell');
+  const isDeviceOffline = (device: Device) => {
+    return !device.online;
   };
 
-  const handleHubClick = (e: React.MouseEvent) => {
+  const handleDeviceClick = (device: Device) => (e: React.MouseEvent) => {
     e.stopPropagation();
-    router.push('/hub');
+    // Navigate to device-specific page if available
+    if (device.type === 'doorbell') {
+      router.push('/doorbell');
+    } else if (device.type === 'hub' || device.type === 'main_lcd') {
+      router.push('/hub');
+    }
   };
+
+  const devices = devicesStatus?.devices || [];
 
   return (
     <div className="card card-large">
@@ -56,95 +58,60 @@ export function SystemStatusCard({ devicesStatus, isExpanded = false }: SystemSt
       </div>
       <div className="card-content">
         <div className="system-status-grid">
+          {/* All Devices */}
+          {devices.map((device) => (
+            <div
+              key={device.device_id}
+              className={`device-status-item ${device.type === 'doorbell' || device.type === 'hub' || device.type === 'main_lcd' ? 'device-clickable' : ''}`}
+              onClick={device.type === 'doorbell' || device.type === 'hub' || device.type === 'main_lcd' ? handleDeviceClick(device) : undefined}
+              style={device.type === 'doorbell' || device.type === 'hub' || device.type === 'main_lcd' ? { cursor: 'pointer' } : {}}
+            >
+              <div className="device-status-header">
+                <h3>{device.name?.toUpperCase() || device.type?.toUpperCase()}</h3>
+                <div className="status-group">
+                  <span className={`status-indicator ${getDeviceStatusClass(device.online, device.last_seen)}`}>
+                    {getDeviceStatusText(device.online, device.last_seen)}
+                  </span>
+                  {device.battery !== undefined && (
+                    <div className={`battery-indicator ${getBatteryClass(device.battery)}`}>
+                      {getBatteryIcon(device.battery)}
+                      <span>{device.battery}%</span>
+                    </div>
+                  )}
+                </div>
+              </div>
 
+              {/* Expanded view - show additional details */}
+              {isExpanded && (
+                <div className="device-info">
+                  <p>Last Heartbeat: {device.last_seen ? new Date(device.last_seen).toLocaleString() : 'Never'}</p>
+                  <p>Device ID: {device.device_id || 'N/A'}</p>
+                  <p>IP Address: {isDeviceOffline(device) ? '-' : (device.ip_address || 'N/A')}</p>
+                  <p>WiFi Signal: {isDeviceOffline(device) ? '-' : (device.wifi_rssi ? `${device.wifi_rssi} dBm` : 'N/A')}</p>
+                  <p>Free Heap: {isDeviceOffline(device) ? '-' : (device.free_heap ? `${(device.free_heap / 1024).toFixed(1)} KB` : 'N/A')}</p>
+                  <p>Uptime: {isDeviceOffline(device) ? '-' : (device.uptime_ms ? `${Math.floor(device.uptime_ms / 3600000)}h ${Math.floor((device.uptime_ms % 3600000) / 60000)}m` : 'N/A')}</p>
+                  {device.battery !== undefined && (
+                    <p>Battery: {device.battery}%</p>
+                  )}
+                </div>
+              )}
 
-          {/* Doorbell Status */}
-          <div
-            className="device-status-item device-clickable"
-            onClick={handleDoorbellClick}
-            style={{ cursor: 'pointer' }}
-          >
-            <div className="device-status-header">
-              <h3>DOORBELL</h3>
-              <div className="status-group">
-                <span className={`status-indicator ${getDeviceStatusClass(doorbellDevice?.online || false, doorbellDevice?.last_seen)}`}>
-                  {getDeviceStatusText(doorbellDevice?.online || false, doorbellDevice?.last_seen)}
-                </span>
-                {doorbellDevice?.battery !== undefined && (
-                  <div className={`battery-indicator ${getBatteryClass(doorbellDevice.battery)}`}>
-                    {getBatteryIcon(doorbellDevice.battery)}
-                    <span>{doorbellDevice.battery}%</span>
-                  </div>
-                )}
+              {/* Show hint for clickable devices */}
+              {(device.type === 'doorbell' || device.type === 'hub' || device.type === 'main_lcd') && (
+                <p className="device-hint">Click to configure →</p>
+              )}
+            </div>
+          ))}
+
+          {/* No devices found */}
+          {devices.length === 0 && (
+            <div className="device-status-item">
+              <div className="device-info">
+                <p>No devices found</p>
               </div>
             </div>
-            {doorbellDevice && (
-              <div className="device-info">
-                <p>Last Heartbeat: {doorbellDevice.last_seen ? new Date(doorbellDevice.last_seen).toLocaleString() : 'Never'}</p>
-                <p>Device ID: {doorbellDevice.device_id || 'N/A'}</p>
-                {doorbellDevice.battery !== undefined && (
-                  <p>Battery: {doorbellDevice.battery}%</p>
-                )}
-                {isExpanded && (
-                  <>
-                    <p>IP Address: {doorbellDevice.ip_address || 'N/A'}</p>
-                    <p>WiFi Signal: {doorbellDevice.wifi_rssi ? `${doorbellDevice.wifi_rssi} dBm` : 'N/A'}</p>
-                    <p>Free Heap: {doorbellDevice.free_heap ? `${(doorbellDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
-                  </>
-                )}
-              </div>
-            )}
-            {!doorbellDevice && (
-              <div className="device-info">
-                <p>No doorbell device found</p>
-              </div>
-            )}
-            <p className="device-hint">Click to configure →</p>
-          </div>
+          )}
 
-          {/* Hub Status */}
-          <div
-            className="device-status-item device-clickable"
-            onClick={handleHubClick}
-            style={{ cursor: 'pointer' }}
-          >
-            <div className="device-status-header">
-              <h3>HUB</h3>
-              <div className="status-group">
-                <span className={`status-indicator ${getDeviceStatusClass(hubDevice?.online || false, hubDevice?.last_seen)}`}>
-                  {getDeviceStatusText(hubDevice?.online || false, hubDevice?.last_seen)}
-                </span>
-                {hubDevice?.battery !== undefined && (
-                  <div className={`battery-indicator ${getBatteryClass(hubDevice.battery)}`}>
-                    {getBatteryIcon(hubDevice.battery)}
-                    <span>{hubDevice.battery}%</span>
-                  </div>
-                )}
-              </div>
-            </div>
-            {hubDevice && (
-              <div className="device-info">
-                <p>Last Heartbeat: {hubDevice.last_seen ? new Date(hubDevice.last_seen).toLocaleString() : 'Never'}</p>
-                <p>Device ID: {hubDevice.device_id || 'N/A'}</p>
-                {hubDevice.battery !== undefined && (
-                  <p>Battery: {hubDevice.battery}%</p>
-                )}
-                {isExpanded && (
-                  <>
-                    <p>IP Address: {hubDevice.ip_address || 'N/A'}</p>
-                    <p>WiFi Signal: {hubDevice.wifi_rssi ? `${hubDevice.wifi_rssi} dBm` : 'N/A'}</p>
-                    <p>Free Heap: {hubDevice.free_heap ? `${(hubDevice.free_heap / 1024).toFixed(1)} KB` : 'N/A'}</p>
-                  </>
-                )}
-              </div>
-            )}
-            {!hubDevice && (
-              <div className="device-info">
-                <p>No hub device found</p>
-              </div>
-            )}
-            <p className="device-hint">Click to configure →</p>
-          </div>
           {/* System Overview */}
           <div className="device-status-item system-overview">
             <h3 style={{ marginBottom: 'var(--spacing-sm)' }}>SYSTEM HEALTH</h3>


### PR DESCRIPTION
- Display all devices from devicesStatus.devices array instead of just doorbell and hub
- Compact view: show device name, online/offline status, and battery indicator
- Expanded view: show full details including IP, WiFi, heap, uptime, and battery
- Show "-" for IP Address, WiFi Signal, Free Heap, and Uptime when device is offline
- Maintain clickable navigation for doorbell and hub devices