### PR TITLE
Fix: Dashboard now shows Hub real data + mock rooms (not Hub only)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -142,8 +142,11 @@ export default function DashboardPage() {
 
   // Generate mock data for features not yet implemented
   const alerts = generateMockAlerts();
-  // Use real Hub sensor data if available, fallback to mock data
-  const temperatureData = hubSensorData.length > 0 ? hubSensorData : generateMockTemperatureData();
+  // Combine real Hub sensor data with mock data for other rooms
+  const mockRooms = generateMockTemperatureData();
+  const temperatureData = hubSensorData.length > 0
+    ? [...hubSensorData, ...mockRooms]  // Hub real data + mock rooms
+    : mockRooms;  // All mock if Hub offline
   const gasReadings = generateMockGasReadings();
   const doorsWindows = generateMockDoorsWindows();
 


### PR DESCRIPTION
PROBLEM:
Previous commit replaced ALL room data with only Hub data, showing just one room instead of Hub + Living Room + Bedroom + Kitchen.

FIX:
Changed temperatureData to combine Hub real data with mock rooms:
- Hub: Real temperature/humidity from API
- Living Room: Mock data (no sensor yet)
- Bedroom: Mock data (no sensor yet)
- Kitchen: Mock data (no sensor yet)

IMPLEMENTATION:
const temperatureData = hubSensorData.length > 0
  ? [...hubSensorData, ...mockRooms]  // Hub real + 3 mock rooms
  : mockRooms;                         // All mock if Hub offline

RESULT:
Dashboard Temperature Card now displays 4 rooms total:
- 1 real (Hub with actual DHT11 sensor data)
- 3 mock (other rooms until sensors added to database)

This provides a better user experience showing the full dashboard while gradually migrating from mock to real data.