### PR TITLE
Add camera and microphone streaming to Backend

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(src_dirs ./ app control network uart spi jpeg recognition audio)
+set(src_dirs ./ app control network uart spi jpeg recognition audio backend)
 
-set(include_dirs ./ app control network uart spi jpeg recognition audio)
+set(include_dirs ./ app control network uart spi jpeg recognition audio backend)
 
 set(requires who_detect_app
              who_detect
@@ -9,6 +9,7 @@ set(requires who_detect_app
              human_face_recognition
              json
              esp_http_server
+             esp_http_client
              nvs_flash
              esp_wifi
              esp_event

--- a/main/backend/backend_stream.cpp
+++ b/main/backend/backend_stream.cpp
@@ -1,0 +1,484 @@
+#include "backend_stream.hpp"
+#include "esp_log.h"
+#include "esp_http_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include <cstring>
+#include <cstdlib>
+
+namespace backend_stream {
+
+static const char *TAG = "BackendStream";
+
+// Queue handles
+static QueueHandle_t camera_queue = nullptr;
+static QueueHandle_t audio_queue = nullptr;
+
+// Task handles
+static TaskHandle_t camera_task_handle = nullptr;
+static TaskHandle_t audio_task_handle = nullptr;
+
+// Streaming state
+static bool camera_streaming_active = false;
+static bool audio_streaming_active = false;
+
+// Statistics
+static StreamStats stats = {0};
+
+// Frame rate limiting for camera
+static uint32_t last_frame_sent_time = 0;
+static const uint32_t FRAME_INTERVAL_MS = 200;  // 5 FPS
+
+// ============================================================================
+// Internal: Send camera frame to backend
+// ============================================================================
+static esp_err_t send_camera_frame_blocking(CameraFrame* frame) {
+    uint32_t start_time = xTaskGetTickCount() * portTICK_PERIOD_MS;
+
+    // Build URL
+    char url[256];
+    snprintf(url, sizeof(url), "http://%s:%d/api/v1/devices/doorbell/camera-stream",
+             BACKEND_SERVER_HOST, BACKEND_SERVER_PORT);
+
+    // Create boundary for multipart
+    char boundary[64];
+    snprintf(boundary, sizeof(boundary), "----ESP32CameraFrame%lu", (unsigned long)frame->timestamp);
+
+    // Build multipart form data header
+    char form_header[512];
+    int header_len = snprintf(form_header, sizeof(form_header),
+        "--%s\r\n"
+        "Content-Disposition: form-data; name=\"device_id\"\r\n\r\n"
+        "%s\r\n"
+        "--%s\r\n"
+        "Content-Disposition: form-data; name=\"frame_id\"\r\n\r\n"
+        "%u\r\n"
+        "--%s\r\n"
+        "Content-Disposition: form-data; name=\"timestamp\"\r\n\r\n"
+        "%lu\r\n"
+        "--%s\r\n"
+        "Content-Disposition: form-data; name=\"frame\"; filename=\"frame.jpg\"\r\n"
+        "Content-Type: image/jpeg\r\n\r\n",
+        boundary, DEVICE_ID,
+        boundary, frame->frame_id,
+        boundary, (unsigned long)frame->timestamp,
+        boundary);
+
+    // Build footer
+    char form_footer[128];
+    int footer_len = snprintf(form_footer, sizeof(form_footer), "\r\n--%s--\r\n", boundary);
+
+    // Calculate total content length
+    size_t content_length = header_len + frame->size + footer_len;
+
+    // Configure HTTP client
+    esp_http_client_config_t config = {};
+    config.url = url;
+    config.method = HTTP_METHOD_POST;
+    config.timeout_ms = 5000;
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == nullptr) {
+        ESP_LOGE(TAG, "Failed to init HTTP client");
+        stats.camera_frames_failed++;
+        return ESP_FAIL;
+    }
+
+    // Set headers
+    char content_type_header[128];
+    snprintf(content_type_header, sizeof(content_type_header),
+             "multipart/form-data; boundary=%s", boundary);
+    esp_http_client_set_header(client, "Content-Type", content_type_header);
+
+    char auth_header[256];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", API_TOKEN);
+    esp_http_client_set_header(client, "Authorization", auth_header);
+
+    // Open connection and send headers
+    esp_err_t err = esp_http_client_open(client, content_length);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open HTTP connection: %s", esp_err_to_name(err));
+        esp_http_client_cleanup(client);
+        stats.camera_frames_failed++;
+        return err;
+    }
+
+    // Send form header
+    int written = esp_http_client_write(client, form_header, header_len);
+    if (written < 0) {
+        ESP_LOGE(TAG, "Failed to write form header");
+        esp_http_client_cleanup(client);
+        stats.camera_frames_failed++;
+        return ESP_FAIL;
+    }
+
+    // Send frame data in chunks
+    const size_t CHUNK_SIZE = 1024;
+    size_t sent = 0;
+    while (sent < frame->size) {
+        size_t to_send = (frame->size - sent > CHUNK_SIZE) ? CHUNK_SIZE : (frame->size - sent);
+        written = esp_http_client_write(client, (const char*)(frame->data + sent), to_send);
+        if (written < 0) {
+            ESP_LOGE(TAG, "Failed to write frame data at %zu/%zu", sent, frame->size);
+            esp_http_client_cleanup(client);
+            stats.camera_frames_failed++;
+            return ESP_FAIL;
+        }
+        sent += written;
+
+        // Yield occasionally to prevent watchdog
+        if (sent % 4096 == 0) {
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+    }
+
+    // Send footer
+    written = esp_http_client_write(client, form_footer, footer_len);
+    if (written < 0) {
+        ESP_LOGE(TAG, "Failed to write form footer");
+        esp_http_client_cleanup(client);
+        stats.camera_frames_failed++;
+        return ESP_FAIL;
+    }
+
+    // Fetch response
+    int content_len = esp_http_client_fetch_headers(client);
+    int status_code = esp_http_client_get_status_code(client);
+
+    esp_http_client_cleanup(client);
+
+    uint32_t duration = (xTaskGetTickCount() * portTICK_PERIOD_MS) - start_time;
+    stats.last_send_duration_ms = duration;
+
+    if (status_code == 200 || status_code == 201) {
+        stats.camera_frames_sent++;
+
+        // Log periodically
+        if (stats.camera_frames_sent % 10 == 0) {
+            ESP_LOGI(TAG, "Camera frame %u sent (%zu bytes, %lu ms)",
+                     frame->frame_id, frame->size, (unsigned long)duration);
+        }
+        return ESP_OK;
+    } else {
+        ESP_LOGW(TAG, "Backend returned status %d", status_code);
+        stats.camera_frames_failed++;
+        return ESP_FAIL;
+    }
+}
+
+// ============================================================================
+// Internal: Send audio chunk to backend
+// ============================================================================
+static esp_err_t send_audio_chunk_blocking(AudioChunk* chunk) {
+    char url[256];
+    snprintf(url, sizeof(url), "http://%s:%d/api/v1/devices/doorbell/mic-stream",
+             BACKEND_SERVER_HOST, BACKEND_SERVER_PORT);
+
+    esp_http_client_config_t config = {};
+    config.url = url;
+    config.method = HTTP_METHOD_POST;
+    config.timeout_ms = 3000;
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == nullptr) {
+        ESP_LOGE(TAG, "Failed to init HTTP client for audio");
+        stats.audio_chunks_failed++;
+        return ESP_FAIL;
+    }
+
+    // Set headers
+    esp_http_client_set_header(client, "Content-Type", "application/octet-stream");
+    esp_http_client_set_header(client, "X-Device-ID", DEVICE_ID);
+
+    char auth_header[256];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", API_TOKEN);
+    esp_http_client_set_header(client, "Authorization", auth_header);
+
+    char sequence_header[32];
+    snprintf(sequence_header, sizeof(sequence_header), "%lu", (unsigned long)chunk->sequence);
+    esp_http_client_set_header(client, "X-Sequence", sequence_header);
+
+    // Open connection and send
+    esp_err_t err = esp_http_client_open(client, chunk->size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open HTTP connection for audio");
+        esp_http_client_cleanup(client);
+        stats.audio_chunks_failed++;
+        return err;
+    }
+
+    int written = esp_http_client_write(client, (const char*)chunk->data, chunk->size);
+    if (written < 0) {
+        ESP_LOGE(TAG, "Failed to write audio data");
+        esp_http_client_cleanup(client);
+        stats.audio_chunks_failed++;
+        return ESP_FAIL;
+    }
+
+    int content_len = esp_http_client_fetch_headers(client);
+    int status_code = esp_http_client_get_status_code(client);
+
+    esp_http_client_cleanup(client);
+
+    if (status_code == 200 || status_code == 201) {
+        stats.audio_chunks_sent++;
+
+        // Log periodically
+        if (stats.audio_chunks_sent % 50 == 0) {
+            ESP_LOGI(TAG, "Audio chunk %lu sent (%zu bytes, total: %lu KB)",
+                     (unsigned long)chunk->sequence, chunk->size,
+                     (unsigned long)(stats.audio_chunks_sent * chunk->size) / 1024);
+        }
+        return ESP_OK;
+    } else {
+        ESP_LOGW(TAG, "Audio backend returned status %d", status_code);
+        stats.audio_chunks_failed++;
+        return ESP_FAIL;
+    }
+}
+
+// ============================================================================
+// FreeRTOS Tasks
+// ============================================================================
+static void camera_stream_task(void* param) {
+    ESP_LOGI(TAG, "Camera streaming task started");
+
+    CameraFrame frame;
+
+    while (true) {
+        // Wait for frames in queue
+        if (xQueueReceive(camera_queue, &frame, portMAX_DELAY) == pdTRUE) {
+            // Only send if streaming is active
+            if (camera_streaming_active) {
+                send_camera_frame_blocking(&frame);
+            }
+
+            // Free frame buffer
+            if (frame.data != nullptr) {
+                free(frame.data);
+            }
+
+            // Delay between frames
+            vTaskDelay(pdMS_TO_TICKS(50));
+        }
+    }
+}
+
+static void audio_stream_task(void* param) {
+    ESP_LOGI(TAG, "Audio streaming task started");
+
+    AudioChunk chunk;
+
+    while (true) {
+        // Wait for audio chunks in queue
+        if (xQueueReceive(audio_queue, &chunk, portMAX_DELAY) == pdTRUE) {
+            // Only send if streaming is active
+            if (audio_streaming_active) {
+                send_audio_chunk_blocking(&chunk);
+            }
+
+            // Free chunk buffer
+            if (chunk.data != nullptr) {
+                free(chunk.data);
+            }
+
+            // Minimal delay
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+    }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+esp_err_t init() {
+    if (camera_queue != nullptr) {
+        ESP_LOGW(TAG, "Already initialized");
+        return ESP_OK;
+    }
+
+    // Create queues
+    camera_queue = xQueueCreate(3, sizeof(CameraFrame));
+    audio_queue = xQueueCreate(10, sizeof(AudioChunk));
+
+    if (camera_queue == nullptr || audio_queue == nullptr) {
+        ESP_LOGE(TAG, "Failed to create queues");
+        return ESP_FAIL;
+    }
+
+    // Create camera streaming task on Core 0
+    BaseType_t ret = xTaskCreatePinnedToCore(
+        camera_stream_task,
+        "camera_stream",
+        8192,  // 8KB stack
+        nullptr,
+        3,  // Priority 3
+        &camera_task_handle,
+        0   // Core 0
+    );
+
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create camera stream task");
+        return ESP_FAIL;
+    }
+
+    // Create audio streaming task on Core 0
+    ret = xTaskCreatePinnedToCore(
+        audio_stream_task,
+        "audio_stream",
+        6144,  // 6KB stack
+        nullptr,
+        3,  // Priority 3
+        &audio_task_handle,
+        0   // Core 0
+    );
+
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create audio stream task");
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Backend streaming initialized (target: %s:%d)",
+             BACKEND_SERVER_HOST, BACKEND_SERVER_PORT);
+
+    return ESP_OK;
+}
+
+void start_camera_streaming() {
+    camera_streaming_active = true;
+    last_frame_sent_time = 0;
+    ESP_LOGI(TAG, "Camera streaming started");
+}
+
+void stop_camera_streaming() {
+    camera_streaming_active = false;
+    ESP_LOGI(TAG, "Camera streaming stopped");
+}
+
+bool is_camera_streaming() {
+    return camera_streaming_active;
+}
+
+void start_audio_streaming() {
+    audio_streaming_active = true;
+    ESP_LOGI(TAG, "Audio streaming started");
+}
+
+void stop_audio_streaming() {
+    audio_streaming_active = false;
+    ESP_LOGI(TAG, "Audio streaming stopped");
+}
+
+bool is_audio_streaming() {
+    return audio_streaming_active;
+}
+
+esp_err_t queue_camera_frame(const uint8_t* jpeg_data, size_t jpeg_size, uint16_t frame_id) {
+    if (camera_queue == nullptr || !camera_streaming_active) {
+        return ESP_FAIL;
+    }
+
+    if (jpeg_size > MAX_FRAME_SIZE) {
+        ESP_LOGW(TAG, "Frame too large: %zu bytes", jpeg_size);
+        return ESP_FAIL;
+    }
+
+    // Rate limiting
+    uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+    if (last_frame_sent_time > 0 && (now - last_frame_sent_time) < FRAME_INTERVAL_MS) {
+        return ESP_FAIL;  // Drop frame
+    }
+
+    CameraFrame frame;
+    frame.frame_id = frame_id;
+    frame.timestamp = now;
+    frame.size = jpeg_size;
+
+    // Allocate and copy frame data
+    frame.data = (uint8_t*)malloc(jpeg_size);
+    if (frame.data == nullptr) {
+        ESP_LOGE(TAG, "Failed to allocate frame buffer");
+        return ESP_FAIL;
+    }
+    memcpy(frame.data, jpeg_data, jpeg_size);
+
+    // Try to queue (don't block)
+    if (xQueueSend(camera_queue, &frame, 0) != pdTRUE) {
+        ESP_LOGW(TAG, "Camera queue full, dropping frame");
+        free(frame.data);
+        stats.camera_queue_overflows++;
+        return ESP_FAIL;
+    }
+
+    last_frame_sent_time = now;
+    return ESP_OK;
+}
+
+esp_err_t queue_audio_chunk(const uint8_t* audio_data, size_t audio_size, uint32_t sequence) {
+    if (audio_queue == nullptr || !audio_streaming_active) {
+        return ESP_FAIL;
+    }
+
+    if (audio_size > MAX_AUDIO_CHUNK_SIZE) {
+        ESP_LOGW(TAG, "Audio chunk too large: %zu bytes", audio_size);
+        return ESP_FAIL;
+    }
+
+    AudioChunk chunk;
+    chunk.sequence = sequence;
+    chunk.timestamp = xTaskGetTickCount() * portTICK_PERIOD_MS;
+    chunk.size = audio_size;
+
+    // Allocate and copy audio data
+    chunk.data = (uint8_t*)malloc(audio_size);
+    if (chunk.data == nullptr) {
+        ESP_LOGE(TAG, "Failed to allocate audio buffer");
+        return ESP_FAIL;
+    }
+    memcpy(chunk.data, audio_data, audio_size);
+
+    // Try to queue (don't block)
+    if (xQueueSend(audio_queue, &chunk, 0) != pdTRUE) {
+        ESP_LOGW(TAG, "Audio queue full, dropping chunk");
+        free(chunk.data);
+        stats.audio_queue_overflows++;
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+StreamStats get_stats() {
+    return stats;
+}
+
+void cleanup() {
+    stop_camera_streaming();
+    stop_audio_streaming();
+
+    if (camera_task_handle != nullptr) {
+        vTaskDelete(camera_task_handle);
+        camera_task_handle = nullptr;
+    }
+
+    if (audio_task_handle != nullptr) {
+        vTaskDelete(audio_task_handle);
+        audio_task_handle = nullptr;
+    }
+
+    if (camera_queue != nullptr) {
+        vQueueDelete(camera_queue);
+        camera_queue = nullptr;
+    }
+
+    if (audio_queue != nullptr) {
+        vQueueDelete(audio_queue);
+        audio_queue = nullptr;
+    }
+
+    ESP_LOGI(TAG, "Backend streaming cleaned up");
+}
+
+} // namespace backend_stream

--- a/main/backend/backend_stream.hpp
+++ b/main/backend/backend_stream.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "esp_err.h"
+#include <cstdint>
+
+namespace backend_stream {
+
+// Backend server configuration
+#define BACKEND_SERVER_HOST "embedded-smarthome.fly.dev"
+#define BACKEND_SERVER_PORT 80
+#define DEVICE_ID "db_camera_001"
+#define API_TOKEN "d8ac2f1ee97b4a8b3f299696773e807e735284c47cfc30aadef1287e10a53b6d"
+
+// Maximum frame/chunk sizes
+#define MAX_FRAME_SIZE 50000  // 50KB for JPEG frames
+#define MAX_AUDIO_CHUNK_SIZE 2048  // 2KB for audio chunks
+
+/**
+ * Camera frame structure for backend streaming
+ */
+struct CameraFrame {
+    uint8_t* data;
+    size_t size;
+    uint16_t frame_id;
+    uint32_t timestamp;
+};
+
+/**
+ * Audio chunk structure for backend streaming
+ */
+struct AudioChunk {
+    uint8_t* data;
+    size_t size;
+    uint32_t sequence;
+    uint32_t timestamp;
+};
+
+/**
+ * Streaming statistics
+ */
+struct StreamStats {
+    uint32_t camera_frames_sent;
+    uint32_t camera_frames_failed;
+    uint32_t camera_queue_overflows;
+    uint32_t audio_chunks_sent;
+    uint32_t audio_chunks_failed;
+    uint32_t audio_queue_overflows;
+    uint32_t last_send_duration_ms;
+};
+
+/**
+ * Initialize backend streaming module
+ * Creates FreeRTOS tasks and queues for camera and audio streaming
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t init();
+
+/**
+ * Start/stop camera frame streaming to backend
+ */
+void start_camera_streaming();
+void stop_camera_streaming();
+bool is_camera_streaming();
+
+/**
+ * Start/stop audio streaming to backend
+ */
+void start_audio_streaming();
+void stop_audio_streaming();
+bool is_audio_streaming();
+
+/**
+ * Queue a camera frame for backend transmission
+ * Non-blocking - copies frame data and returns immediately
+ *
+ * @param jpeg_data Pointer to JPEG frame data
+ * @param jpeg_size Size of JPEG data in bytes
+ * @param frame_id Frame sequence number
+ * @return ESP_OK if queued successfully
+ */
+esp_err_t queue_camera_frame(const uint8_t* jpeg_data, size_t jpeg_size, uint16_t frame_id);
+
+/**
+ * Queue an audio chunk for backend transmission
+ * Non-blocking - copies audio data and returns immediately
+ *
+ * @param audio_data Pointer to PCM audio data (int16_t samples)
+ * @param audio_size Size of audio data in bytes
+ * @param sequence Chunk sequence number
+ * @return ESP_OK if queued successfully
+ */
+esp_err_t queue_audio_chunk(const uint8_t* audio_data, size_t audio_size, uint32_t sequence);
+
+/**
+ * Get streaming statistics
+ */
+StreamStats get_stats();
+
+/**
+ * Cleanup backend streaming module
+ */
+void cleanup();
+
+} // namespace backend_stream

--- a/main/network/http_server.cpp
+++ b/main/network/http_server.cpp
@@ -10,6 +10,7 @@
 #include "freertos/event_groups.h"
 #include "i2s_microphone.hpp"
 #include "JpegEncoder.hpp"
+#include "backend/backend_stream.hpp"
 #include <cstring>
 
 static const char *TAG = "HTTP_SERVER";
@@ -42,49 +43,45 @@ static esp_err_t status_handler(httpd_req_t *req)
     return httpd_resp_sendstr(req, "Webpage running");
 }
 
-// Audio streaming handler - streams PCM audio data
+// Audio streaming handler - sends PCM audio data to backend
 static esp_err_t audio_stream_handler(httpd_req_t *req)
 {
-    // Try buffered microphone first, fall back to legacy
+    // This endpoint now triggers backend streaming instead of local HTTP streaming
     if (!g_microphone || !g_microphone->is_running()) {
         httpd_resp_set_status(req, "503 Service Unavailable");
         httpd_resp_sendstr(req, "Microphone not running");
         return ESP_OK;
     }
 
-    // Set headers for streaming audio with minimal buffering
-    httpd_resp_set_type(req, "audio/pcm");
-    httpd_resp_set_hdr(req, "Cache-Control", "no-cache, no-store, must-revalidate");
-    httpd_resp_set_hdr(req, "Pragma", "no-cache");
-    httpd_resp_set_hdr(req, "Expires", "0");
-    httpd_resp_set_hdr(req, "Connection", "keep-alive");
-    httpd_resp_set_hdr(req, "X-Accel-Buffering", "no");  // Disable nginx buffering if present
+    // Start backend audio streaming if not already active
+    if (!backend_stream::is_audio_streaming()) {
+        backend_stream::start_audio_streaming();
+        ESP_LOGI(TAG, "Started backend audio streaming");
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"status\":\"streaming\",\"target\":\"backend\",\"endpoint\":\"/api/v1/devices/doorbell/mic-stream\"}");
 
     const size_t chunk_size = 1024;
     int16_t* audio_buffer = (int16_t*)malloc(chunk_size * sizeof(int16_t));
 
     if (!audio_buffer) {
-        ESP_LOGE(TAG, "Failed to allocate audio buffer for streaming");
-        httpd_resp_set_status(req, "500 Internal Server Error");
-        httpd_resp_sendstr(req, "Out of memory");
+        ESP_LOGE(TAG, "Failed to allocate audio buffer");
         return ESP_OK;
     }
 
-    ESP_LOGI(TAG, "Audio stream started with gain boost");
+    ESP_LOGI(TAG, "Audio streaming to backend started");
 
-    uint32_t dropped_chunks = 0;
+    uint32_t sequence = 0;
     uint32_t sent_chunks = 0;
-    uint32_t total_samples = 0;
 
-    // Audio gain multiplier (2 = 2x volume, 4 = 4x volume, etc.)
-    const int16_t gain = 4;  // Start with 4x gain
+    // Audio gain multiplier
+    const int16_t gain = 4;
 
-    // Stream audio chunks until client disconnects
-    uint32_t read_attempts = 0;
+    // Read audio and send to backend
     while (true) {
-        // Check if microphone is still running before reading
         if (!g_microphone || !g_microphone->is_running()) {
-            ESP_LOGI(TAG, "Microphone stopped, ending audio stream");
+            ESP_LOGI(TAG, "Microphone stopped");
             break;
         }
 
@@ -92,44 +89,33 @@ static esp_err_t audio_stream_handler(httpd_req_t *req)
         esp_err_t ret = g_microphone->read_audio(audio_buffer, chunk_size * sizeof(int16_t),
                                                    &bytes_read, 100);
 
-        read_attempts++;
-
-        // Debug logging for first few attempts
-        if (read_attempts <= 10) {
-            ESP_LOGI(TAG, "Read #%lu: ret=%s bytes=%zu", read_attempts,
-                     esp_err_to_name(ret), bytes_read);
-        }
-
-        // Accept data even if we got a timeout, as long as we have some bytes
-        // This handles the case where I2S returns partial data with ESP_ERR_TIMEOUT
         if (bytes_read > 0) {
             size_t samples_read = bytes_read / sizeof(int16_t);
 
             // Apply gain to boost volume
             for (size_t i = 0; i < samples_read; i++) {
                 int32_t sample = audio_buffer[i] * gain;
-                // Clamp to prevent overflow/distortion
                 if (sample > 32767) sample = 32767;
                 if (sample < -32768) sample = -32768;
                 audio_buffer[i] = (int16_t)sample;
             }
 
-            // Send audio chunk to client
-            esp_err_t send_ret = httpd_resp_send_chunk(req, (const char*)audio_buffer,
-                                                        samples_read * sizeof(int16_t));
+            // Send audio chunk to backend
+            esp_err_t queue_ret = backend_stream::queue_audio_chunk(
+                (const uint8_t*)audio_buffer,
+                samples_read * sizeof(int16_t),
+                sequence++
+            );
 
-            if (send_ret != ESP_OK) {
-                ESP_LOGW(TAG, "Audio stream client disconnected or send failed");
-                break;
-            }
+            if (queue_ret == ESP_OK) {
+                sent_chunks++;
 
-            sent_chunks++;
-            total_samples += samples_read;
-
-            // Log stats every 5 seconds (~78 chunks @ 1024 samples, 64ms each)
-            if (sent_chunks % 78 == 0) {
-                ESP_LOGI(TAG, "Audio stream stats: sent=%lu samples=%lu",
-                         sent_chunks, total_samples);
+                // Log stats periodically
+                if (sent_chunks % 50 == 0) {
+                    backend_stream::StreamStats stats = backend_stream::get_stats();
+                    ESP_LOGI(TAG, "Audio streaming: queued=%lu sent=%lu failed=%lu",
+                             sent_chunks, stats.audio_chunks_sent, stats.audio_chunks_failed);
+                }
             }
 
             // Yield periodically
@@ -137,7 +123,6 @@ static esp_err_t audio_stream_handler(httpd_req_t *req)
                 vTaskDelay(pdMS_TO_TICKS(1));
             }
         } else if (ret == ESP_ERR_TIMEOUT) {
-            // No data ready - wait a short time and retry
             vTaskDelay(pdMS_TO_TICKS(5));
             continue;
         } else if (ret != ESP_OK) {
@@ -145,20 +130,21 @@ static esp_err_t audio_stream_handler(httpd_req_t *req)
             vTaskDelay(pdMS_TO_TICKS(10));
             continue;
         }
+
+        // Check if we should stop (simulate client disconnect check)
+        if (sent_chunks > 1000) {  // Stream for ~64 seconds max per request
+            break;
+        }
     }
 
-    ESP_LOGI(TAG, "Audio stream ended: sent=%lu chunks, %lu total samples, dropped=%lu",
-             sent_chunks, total_samples, dropped_chunks);
+    ESP_LOGI(TAG, "Audio streaming to backend ended: %lu chunks sent", sent_chunks);
 
     free(audio_buffer);
-
-    // End chunked response
-    httpd_resp_send_chunk(req, NULL, 0);
 
     return ESP_OK;
 }
 
-// MJPEG camera streaming handler
+// Camera streaming handler - sends JPEG frames to backend
 static esp_err_t camera_stream_handler(httpd_req_t *req)
 {
     if (!g_frame_cap || !g_standby_ctrl) {
@@ -174,19 +160,24 @@ static esp_err_t camera_stream_handler(httpd_req_t *req)
         return ESP_OK;
     }
 
-    ESP_LOGI(TAG, "MJPEG stream started");
+    // Start backend camera streaming if not already active
+    if (!backend_stream::is_camera_streaming()) {
+        backend_stream::start_camera_streaming();
+        ESP_LOGI(TAG, "Started backend camera streaming");
+    }
 
-    // Set MJPEG multipart headers
-    httpd_resp_set_type(req, "multipart/x-mixed-replace; boundary=frame");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Cache-Control", "no-cache, no-store, must-revalidate");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"status\":\"streaming\",\"target\":\"backend\",\"endpoint\":\"/api/v1/devices/doorbell/camera-stream\"}");
+
+    ESP_LOGI(TAG, "Camera streaming to backend started");
 
     auto frame_cap_node = g_frame_cap->get_last_node();
-    RawJpegEncoder encoder(50);  // JPEG quality 50 for bandwidth
+    RawJpegEncoder encoder(50);  // JPEG quality 50 (~9KB avg)
 
-    uint32_t frames_sent = 0;
+    uint16_t frame_id = 0;
+    uint32_t frames_queued = 0;
     uint32_t last_report = xTaskGetTickCount();
-    bool logged_format = false;  // Log format only once
+    bool logged_format = false;
 
     while (true) {
         // Peek at latest frame
@@ -201,13 +192,11 @@ static esp_err_t camera_stream_handler(httpd_req_t *req)
             }
 
             bool encoded = false;
-
             const uint8_t *jpeg_data = nullptr;
             uint32_t jpeg_size = 0;
 
             // Check if frame is already JPEG
             if (static_cast<pixformat_t>(frame->format) == PIXFORMAT_JPEG) {
-                // Frame is already JPEG, use directly
                 jpeg_data = static_cast<const uint8_t *>(frame->buf);
                 jpeg_size = frame->len;
                 encoded = true;
@@ -236,42 +225,39 @@ static esp_err_t camera_stream_handler(httpd_req_t *req)
             }
 
             if (encoded && jpeg_data && jpeg_size > 0) {
+                // Send frame to backend
+                esp_err_t queue_ret = backend_stream::queue_camera_frame(
+                    jpeg_data,
+                    jpeg_size,
+                    frame_id++
+                );
 
-                // Send multipart boundary and headers
-                char part_buf[128];  // Increased size to avoid truncation warning
-                snprintf(part_buf, sizeof(part_buf),
-                        "\r\n--frame\r\nContent-Type: image/jpeg\r\nContent-Length: %lu\r\n\r\n",
-                        jpeg_size);
-
-                if (httpd_resp_send_chunk(req, part_buf, strlen(part_buf)) != ESP_OK) {
-                    ESP_LOGI(TAG, "Client disconnected");
-                    break;
+                if (queue_ret == ESP_OK) {
+                    frames_queued++;
                 }
-
-                // Send JPEG data
-                if (httpd_resp_send_chunk(req, (const char*)jpeg_data, jpeg_size) != ESP_OK) {
-                    ESP_LOGI(TAG, "Client disconnected");
-                    break;
-                }
-
-                frames_sent++;
 
                 // Log stats every 5 seconds
                 if (xTaskGetTickCount() - last_report > pdMS_TO_TICKS(5000)) {
-                    ESP_LOGI(TAG, "MJPEG: %lu frames sent", frames_sent);
+                    backend_stream::StreamStats stats = backend_stream::get_stats();
+                    ESP_LOGI(TAG, "Camera streaming: queued=%lu sent=%lu failed=%lu (avg: %lu KB)",
+                             frames_queued, stats.camera_frames_sent, stats.camera_frames_failed,
+                             frames_queued > 0 ? (jpeg_size / 1024) : 0);
                     last_report = xTaskGetTickCount();
                 }
             }
         }
 
-        // Limit to ~10 FPS to save bandwidth
-        vTaskDelay(pdMS_TO_TICKS(100));
+        // Limit to ~5 FPS (backend rate limits to this anyway)
+        vTaskDelay(pdMS_TO_TICKS(200));
+
+        // Stream for ~60 seconds max per request
+        if (frames_queued > 300) {
+            break;
+        }
     }
 
-    ESP_LOGI(TAG, "MJPEG stream ended: %lu frames sent", frames_sent);
+    ESP_LOGI(TAG, "Camera streaming to backend ended: %lu frames queued", frames_queued);
 
-    // End chunked response
-    httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }
 
@@ -336,6 +322,15 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base,
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
         ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+
+        // Initialize backend streaming (must have network connectivity)
+        esp_err_t ret = backend_stream::init();
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "Backend streaming module initialized");
+        } else {
+            ESP_LOGE(TAG, "Failed to initialize backend streaming: %d", ret);
+        }
+
         g_server = start_webserver();
     }
 }


### PR DESCRIPTION
Replaced local HTTP streaming with backend server streaming for Doorbell_Camera:

**Backend Streaming Module** (main/backend/)
- backend_stream.hpp/cpp: New module for streaming to backend
- Non-blocking FreeRTOS task-based operation
- Separate tasks for camera frames (Core 0) and audio chunks (Core 0)
- Queue-based buffering with overflow protection
- Rate-limited camera streaming: 5 FPS (200ms interval)
- Target: http://embedded-smarthome.fly.dev

**Modified HTTP Server** (main/network/http_server.cpp)
- Replaced /camera/stream endpoint: Now sends JPEG frames to backend
- Replaced /audio/stream endpoint: Now sends PCM audio to backend
- Preserved JPEG quality 50 (~9KB average per frame)
- Audio gain boost maintained (4x volume)
- Endpoints return JSON status instead of streaming locally
- Initialized backend_stream module on WiFi connection

**Updated Build Configuration** (main/CMakeLists.txt)
- Added backend directory to src_dirs and include_dirs
- Added esp_http_client dependency for backend HTTP requests

**Backend Endpoints:**
- Camera: POST /api/v1/devices/doorbell/camera-stream
- Microphone: POST /api/v1/devices/doorbell/mic-stream
- Device ID: db_camera_001
- Authentication: Bearer token

**Resource Usage:**
- Camera stream task: 8KB stack, priority 3, Core 0
- Audio stream task: 6KB stack, priority 3, Core 0
- Queue sizes: 3 frames (camera), 10 chunks (audio)
- Automatic rate limiting and frame/chunk dropping

**Quality Preserved:**
- JPEG quality: 50 (maintains ~9KB average image size)
- Audio: 16kHz PCM with 4x gain boost
- Frame rate: 5 FPS (bandwidth optimized)

This implementation removes local WiFi streaming and sends all data directly to the backend server for centralized processing.