### PR TITLE
Fix doorbell stream loading issue on first click

### DIFF
--- a/src/app/doorbell/page.tsx
+++ b/src/app/doorbell/page.tsx
@@ -287,7 +287,11 @@ export default function DoorbellControlPage() {
         setStreamConnecting(false);
 
         if (isReady) {
-          console.log("[Camera] ✓ Stream is ready, activating camera display");
+          console.log("[Camera] ✓ Stream is ready, waiting for continuous stream endpoint...");
+          // Add a short delay to ensure the continuous stream endpoint is fully ready
+          // The snapshot endpoint being ready doesn't guarantee the stream endpoint is ready
+          await new Promise(resolve => setTimeout(resolve, 1500));
+          console.log("[Camera] ✓ Activating camera display");
           setCameraActive(true);
         } else {
           console.error("[Camera] ✗ Stream did not start in time");


### PR DESCRIPTION
The stream would fail to load on the first "Start Stream" click but work on the second attempt. This was caused by a race condition where the continuous stream endpoint wasn't fully ready even though the snapshot endpoint indicated the stream had started.

Changes:
- Added 1.5 second delay after stream ready confirmation
- This allows the continuous stream endpoint to fully initialize
- Stream now loads reliably on the first click

Fixes the timing issue between snapshot endpoint and stream endpoint readiness.