### PR TITLE
Add camera view screen and doorbell snapshot functionality

### DIFF
--- a/include/hub_network.h
+++ b/include/hub_network.h
@@ -97,4 +97,18 @@ struct SensorData {
 // Fetch sensor data for a specific sensor device
 bool fetchSensorData(const char* deviceId, SensorData* sensorData);
 
+// ============================================================================
+// Camera Control Functions
+// ============================================================================
+
+// Send command to doorbell camera (camera_start, camera_stop, start_preview)
+bool sendCameraCommand(const char* deviceId, const char* action);
+
+// Fetch camera snapshot from backend
+// Returns: true if successful, false otherwise
+// imageData: buffer to store JPEG data (caller must provide buffer)
+// maxSize: maximum size of buffer
+// actualSize: actual size of received JPEG data
+bool fetchCameraSnapshot(const char* deviceId, uint8_t* imageData, size_t maxSize, size_t* actualSize);
+
 #endif

--- a/include/screen_definitions.h
+++ b/include/screen_definitions.h
@@ -17,7 +17,8 @@ enum Screen
   SCREEN_TEMP_2 = 10,
   SCREEN_MASTER_MENU = 11,
   SCREEN_NOTIFICATION_LOG = 12,
-  SCREEN_COUNT = 13 // Total number of screens
+  SCREEN_CAMERA_VIEW = 13,
+  SCREEN_COUNT = 14 // Total number of screens
 };
 
 // Helper function to get screen name (for debugging)
@@ -51,6 +52,8 @@ inline const char *getScreenName(int screen)
     return "Master Menu";
   case SCREEN_NOTIFICATION_LOG:
     return "Notification Log";
+  case SCREEN_CAMERA_VIEW:
+    return "Camera View";
   default:
     return "Unknown";
   }


### PR DESCRIPTION
Changes to Main_lcd only:
- Added SCREEN_CAMERA_VIEW enum (screen #13)
- Added sendCameraCommand() to send camera start/stop/preview commands
- Added fetchCameraSnapshot() to download JPEG snapshots from backend

Functions use backend API:
- POST /api/v1/devices/:device_id/command (camera_start, camera_stop, start_preview)
- GET /api/v1/stream/snapshot/:device_id

Next step: Implement screen rendering in screen_manager.cpp